### PR TITLE
feat(audio): note-math helpers (midi/hz/cents/nearest)

### DIFF
--- a/src/audio/note-math.ts
+++ b/src/audio/note-math.ts
@@ -1,0 +1,44 @@
+import type { PitchClass } from '@/types/music';
+import { PITCH_CLASSES } from '@/types/music';
+
+const A4_MIDI = 69;
+const A4_HZ = 440;
+
+/** Hz for a MIDI number. A4 = 69 → 440 Hz. */
+export function midiToHz(midi: number): number {
+  return A4_HZ * Math.pow(2, (midi - A4_MIDI) / 12);
+}
+
+/** Fractional MIDI number for a Hz frequency. */
+export function hzToMidi(hz: number): number {
+  return A4_MIDI + 12 * Math.log2(hz / A4_HZ);
+}
+
+/**
+ * Convert (pitch class, octave) to a MIDI number.
+ * Octave follows the scientific pitch notation: C4 = 60, middle C.
+ */
+export function pitchClassToMidi(pc: PitchClass, octave: number): number {
+  const idx = PITCH_CLASSES.indexOf(pc);
+  if (idx < 0) throw new Error(`unknown pitch class: ${pc}`);
+  // C4 = MIDI 60; semitone index within an octave matches PITCH_CLASSES starting from C
+  return (octave + 1) * 12 + idx;
+}
+
+/** Signed cents deviation of `hzSung` from `hzTarget`. Positive = sharp. */
+export function centsBetween(hzSung: number, hzTarget: number): number {
+  if (hzSung <= 0 || hzTarget <= 0) return 0;
+  return 1200 * Math.log2(hzSung / hzTarget);
+}
+
+/**
+ * Snap a Hz frequency to the nearest MIDI note, reporting cents off
+ * the snapped note's frequency.
+ */
+export function nearestMidi(hz: number): { midi: number; cents: number } {
+  if (hz <= 0) return { midi: 0, cents: 0 };
+  const midiFloat = hzToMidi(hz);
+  const midi = Math.round(midiFloat);
+  const cents = centsBetween(hz, midiToHz(midi));
+  return { midi, cents };
+}

--- a/tests/audio/note-math.test.ts
+++ b/tests/audio/note-math.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  midiToHz,
+  hzToMidi,
+  pitchClassToMidi,
+  centsBetween,
+  nearestMidi,
+} from '@/audio/note-math';
+
+describe('note-math', () => {
+  it('A4 is midi 69 and 440 Hz', () => {
+    expect(midiToHz(69)).toBeCloseTo(440, 2);
+    expect(hzToMidi(440)).toBeCloseTo(69, 2);
+  });
+
+  it('C4 is midi 60 and ~261.63 Hz', () => {
+    expect(midiToHz(60)).toBeCloseTo(261.6256, 2);
+  });
+
+  it('pitchClassToMidi places a pitch class in a specific octave', () => {
+    // Octave 4 in MIDI convention: C4 = 60
+    expect(pitchClassToMidi('C', 4)).toBe(60);
+    expect(pitchClassToMidi('A', 4)).toBe(69);
+    expect(pitchClassToMidi('G#', 4)).toBe(68);
+    expect(pitchClassToMidi('B', 4)).toBe(71);
+  });
+
+  it('centsBetween returns positive when sung is sharp of target', () => {
+    // 440 Hz target, 445 Hz sung → ~+20 cents
+    const cents = centsBetween(445, 440);
+    expect(cents).toBeGreaterThan(15);
+    expect(cents).toBeLessThan(25);
+  });
+
+  it('centsBetween returns 0 for identical Hz', () => {
+    expect(centsBetween(440, 440)).toBeCloseTo(0, 4);
+  });
+
+  it('nearestMidi snaps a hz to the nearest midi and reports cents off', () => {
+    const result = nearestMidi(445); // slightly above A4
+    expect(result.midi).toBe(69);
+    expect(result.cents).toBeGreaterThan(15);
+    expect(result.cents).toBeLessThan(25);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/audio/note-math.ts`: pure helpers for `midiToHz`, `hzToMidi`, `pitchClassToMidi`, `centsBetween`, `nearestMidi` — the math foundation every later Plan B audio task builds on.
- Tested via 6 Vitest unit tests covering A4/C4 anchoring, sharps in octave placement, sharp-of-target cent reporting, and snap-to-nearest behavior.

## Why
First task in [Plan B · Audio I/O](docs/plans/2026-04-14-plan-b-audio-io.md). Pure math, zero Web Audio dependencies, so cadence/target/YIN/degree-mapping tasks (Tasks 3–6) can build on a tested kernel.

## Test plan
- [x] `npm run test -- note-math` → 6/6 passing
- [x] `npm run typecheck` → exit 0
- [ ] Reviewer eyeballs the formulas + spec compliance vs. Plan B Task 1