### PR TITLE
chore: gitignore playwright cache + loose downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,6 @@ coverage/
 
 # loose PNG/PDF downloads at the repo root (screenshots, recovery kits, etc.)
 # commit deliberately if you mean to — add the specific file, don't -A.
-*.pdf
-kenbot-*.png
-simplelogin-*.png
+/*.pdf
+/kenbot-*.png
+/simplelogin-*.png

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,14 @@ coverage/
 .env
 .env.local
 .superpowers/
+
+# playwright MCP session artifacts — contains downloaded files, screenshots,
+# accessibility snapshots, and console logs. May include secrets pulled from
+# pages (recovery kits, PATs, credentials). NEVER commit.
+.playwright-mcp/
+
+# loose PNG/PDF downloads at the repo root (screenshots, recovery kits, etc.)
+# commit deliberately if you mean to — add the specific file, don't -A.
+*.pdf
+kenbot-*.png
+simplelogin-*.png


### PR DESCRIPTION
## Summary
- Adds `.playwright-mcp/` to `.gitignore` so playwright MCP session artifacts (downloads, screenshots, accessibility snapshots, console logs) can never be committed.
- Adds `*.pdf`, `kenbot-*.png`, `simplelogin-*.png` to prevent loose secret/context downloads at the repo root from slipping in.

## Why
While doing bot identity setup for PR review automation, the playwright browser downloaded a ProtonMail recovery kit (`.playwright-mcp/proton-recovery-kit.pdf`) into the project directory. The file was never committed (no \`git add -A\` was run), but it was only saved by luck — `.playwright-mcp/` was **not** in `.gitignore`. A single careless \`git add .\` would have committed a personal recovery kit to a public repo. This PR closes that hole.

## Test plan
- [x] \`git check-ignore -v .playwright-mcp/\` confirms the directory is now ignored
- [x] \`git check-ignore -v kenbot-dashboard.png simplelogin-register.png\` confirms loose screenshots are ignored
- [x] No changes to runtime or source code; \`npm run typecheck\` and \`npm run test\` unaffected

## Note
This PR is also the end-to-end test vehicle for the new \`julianken-bot\` fresh-context reviewer subagent. The review on this PR should come from @julianken-bot under the reviewing-as-julianken-bot skill's 12-rule anti-slop rubric.