### PR TITLE
feat(audio): cadence structure generator (I-IV-V-I, major and minor)

### DIFF
--- a/src/audio/cadence-structure.ts
+++ b/src/audio/cadence-structure.ts
@@ -1,0 +1,58 @@
+import type { Key } from '@/types/music';
+import { pitchClassToMidi } from './note-math';
+
+/** Duration of a full I-IV-V-I cadence in seconds (nominal tempo). */
+export const CADENCE_DURATION_SECONDS = 3.2;
+
+const CHORD_DURATION_SEC = 0.7; // each chord plays for ~0.7s
+const CHORD_GAP_SEC = 0.1;     // small gap between chords
+// Step = 0.8s. 4 chords × 0.8s = 3.2s total.
+
+export interface ChordEvent {
+  /** MIDI numbers to play simultaneously. */
+  notes: number[];
+  /** When this chord starts, seconds from cadence start. */
+  startSec: number;
+  /** How long each pitch in this chord sounds. */
+  durationSec: number;
+  /** Roman-numeral label for UI / debugging ('I', 'IV', 'V', 'i', 'iv'). */
+  romanNumeral: string;
+}
+
+/**
+ * Build a I-IV-V-I cadence (major) or i-iv-V-i (minor, harmonic-minor-flavored
+ * with a major V to establish the tonic).
+ *
+ * Voicings are simple root-position triads in the octave centered around middle C.
+ */
+export function buildCadence(key: Key): ChordEvent[] {
+  const tonicMidi = pitchClassToMidi(key.tonic, 4); // octave 4 for middle voicing
+  const isMajor = key.quality === 'major';
+
+  // Semitone offsets from tonic for the three chord roots (I, IV, V):
+  // Major: major triad (0, 4, 7), IV major (5 + (0, 4, 7)), V major (7 + (0, 4, 7))
+  // Minor: minor triad (0, 3, 7), iv minor (5 + (0, 3, 7)), V major (7 + (0, 4, 7))
+  const majorTriad = [0, 4, 7];
+  const minorTriad = [0, 3, 7];
+
+  const I_notes = isMajor ? majorTriad : minorTriad;
+  const IV_notes = isMajor ? majorTriad : minorTriad;
+  const V_notes = majorTriad; // V is major in both major and minor cadences for resolution
+
+  const rootOffsets = [0, 5, 7, 0]; // I, IV, V, I
+  const triads = [I_notes, IV_notes, V_notes, I_notes];
+  const labels = isMajor ? ['I', 'IV', 'V', 'I'] : ['i', 'iv', 'V', 'i'];
+
+  const events: ChordEvent[] = [];
+  for (let i = 0; i < 4; i++) {
+    const rootMidi = tonicMidi + rootOffsets[i]!;
+    const notes = triads[i]!.map((off) => rootMidi + off);
+    events.push({
+      notes,
+      startSec: i * (CHORD_DURATION_SEC + CHORD_GAP_SEC),
+      durationSec: CHORD_DURATION_SEC,
+      romanNumeral: labels[i]!,
+    });
+  }
+  return events;
+}

--- a/tests/audio/cadence-structure.test.ts
+++ b/tests/audio/cadence-structure.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { buildCadence, CADENCE_DURATION_SECONDS } from '@/audio/cadence-structure';
+import { C_MAJOR, G_MAJOR, A_MINOR } from '../helpers/fixtures';
+
+describe('buildCadence', () => {
+  it('returns 4 chord events for a I-IV-V-I cadence in major', () => {
+    const events = buildCadence(C_MAJOR);
+    expect(events.length).toBe(4);
+  });
+
+  it('chord roots are I, IV, V, I in the target key (by MIDI semitones from tonic)', () => {
+    const events = buildCadence(C_MAJOR);
+    // First pitch of each chord is the root
+    const roots = events.map((e) => e.notes[0]!);
+    // Expected root offsets from tonic in semitones: 0, 5, 7, 0
+    const tonic = roots[0]!;
+    const offsets = roots.map((m) => (m - tonic) % 12);
+    expect(offsets).toEqual([0, 5, 7, 0]);
+  });
+
+  it('total cadence duration approximately matches CADENCE_DURATION_SECONDS', () => {
+    const events = buildCadence(C_MAJOR);
+    const last = events[events.length - 1]!;
+    const end = last.startSec + last.durationSec;
+    expect(end).toBeCloseTo(CADENCE_DURATION_SECONDS, 0);
+  });
+
+  it('G major cadence transposes correctly', () => {
+    const c = buildCadence(C_MAJOR);
+    const g = buildCadence(G_MAJOR);
+    // Semitone distance C→G = 7. Each chord root should shift by 7 mod 12.
+    for (let i = 0; i < 4; i++) {
+      const dC = c[i]!.notes[0]!;
+      const dG = g[i]!.notes[0]!;
+      expect(((dG - dC) % 12 + 12) % 12).toBe(7);
+    }
+  });
+
+  it('minor cadence uses i-iv-V-i (major V in natural-minor convention)', () => {
+    const events = buildCadence(A_MINOR);
+    const tonic = events[0]!.notes[0]!;
+    const offsets = events.map((e) => ((e.notes[0]! - tonic) % 12 + 12) % 12);
+    // i, iv, V, i
+    expect(offsets).toEqual([0, 5, 7, 0]);
+    // Check that i is a minor triad (root, minor third, fifth)
+    const iChord = events[0]!.notes;
+    // minor triad: offsets 0, 3, 7 from root
+    const iOffs = iChord.map((m) => m - iChord[0]!).sort((a, b) => a - b);
+    expect(iOffs).toEqual([0, 3, 7]);
+  });
+
+  it('chord events have non-overlapping start times', () => {
+    const events = buildCadence(C_MAJOR);
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i]!.startSec).toBeGreaterThanOrEqual(events[i - 1]!.startSec);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/audio/cadence-structure.ts`: pure-logic module that emits a `ChordEvent[]` sequence representing a I-IV-V-I cadence (major) or i-iv-V-i (minor, with major V for resolution)
- `ChordEvent` carries `notes` (MIDI numbers), `startSec`, `durationSec`, and `romanNumeral` label — no Tone.js, no AudioContext
- Voicings are root-position triads anchored to octave 4 (middle C), transposable to any key via `pitchClassToMidi`
- `CADENCE_DURATION_SECONDS = 3.2` (4 chords × 0.8 s per step) is exported for downstream consumers (Task 7 playback)

## Test plan

- [x] `npm run typecheck` — exits 0, no type errors
- [x] `npm run test` — 104 tests pass (98 pre-existing + 6 new in `tests/audio/cadence-structure.test.ts`)
  - Returns 4 chord events for major key
  - Chord root offsets are [0, 5, 7, 0] semitones from tonic (I-IV-V-I)
  - Total cadence duration matches `CADENCE_DURATION_SECONDS`
  - G major transposes correctly (+7 semitones from C major on every chord root)
  - Minor cadence: root offsets [0, 5, 7, 0] and i-chord is a minor triad (intervals [0, 3, 7])
  - Chord start times are non-decreasing