### PR TITLE
feat(audio): target-note structure generator

### DIFF
--- a/src/audio/target-structure.ts
+++ b/src/audio/target-structure.ts
@@ -40,7 +40,11 @@ export function buildTarget(
     // 'narrow' and 'comfortable' currently produce the same output: octave 4.
     // Distinguishing them is deferred — the register axis exists now in the data model;
     // concrete narrowing rules live with UI settings (Plan C).
+    const tonicMidi = pitchClassToMidi(key.tonic, 4);
     midi = pitchClassToMidi(targetPc, 4);
+    // Satisfy the "no below-tonic notes" contract: if the pitch class lands below
+    // the tonic in octave 4 (e.g. degree 3 of A minor = C4 < A4), shift up one octave.
+    if (midi < tonicMidi) midi += 12;
   }
 
   return {

--- a/src/audio/target-structure.ts
+++ b/src/audio/target-structure.ts
@@ -1,0 +1,51 @@
+import type { Key, Degree } from '@/types/music';
+import type { Register } from '@/types/domain';
+import { semitoneOffset, PITCH_CLASSES } from '@/types/music';
+import { pitchClassToMidi, midiToHz } from './note-math';
+
+export const TARGET_DURATION_SECONDS = 1.5;
+
+export interface NoteEvent {
+  midi: number;
+  hz: number;
+  durationSec: number;
+}
+
+/**
+ * Produce a single scale-degree target note in the specified register.
+ * Registers:
+ *   - 'narrow': degree note sits in the octave starting at tonic4 (no below-tonic notes)
+ *   - 'comfortable': same but can use next octave for degrees 6, 7 if higher feels better
+ *   - 'wide': deterministic octave variation across degrees (for variety)
+ */
+export function buildTarget(
+  key: Key,
+  degree: Degree,
+  register: Register,
+): NoteEvent {
+  const tonicIdx = PITCH_CLASSES.indexOf(key.tonic);
+  const offset = semitoneOffset(degree, key.quality);
+  const targetIdx = (tonicIdx + offset) % 12;
+  // targetIdx is always in [0, 11] because tonicIdx ∈ [0,11] and offset ∈ [0,11].
+  const targetPc = PITCH_CLASSES[targetIdx]!;
+
+  let midi: number;
+
+  if (register === 'wide') {
+    // Interleaved-octave variation: even degrees drop to octave 3 for variety;
+    // odd degrees and degrees 6-7 stay in octave 4.
+    const octave = (degree === 2 || degree === 4) ? 3 : 4;
+    midi = pitchClassToMidi(targetPc, octave);
+  } else {
+    // 'narrow' and 'comfortable' currently produce the same output: octave 4.
+    // Distinguishing them is deferred — the register axis exists now in the data model;
+    // concrete narrowing rules live with UI settings (Plan C).
+    midi = pitchClassToMidi(targetPc, 4);
+  }
+
+  return {
+    midi,
+    hz: midiToHz(midi),
+    durationSec: TARGET_DURATION_SECONDS,
+  };
+}

--- a/tests/audio/target-structure.test.ts
+++ b/tests/audio/target-structure.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { buildTarget, TARGET_DURATION_SECONDS } from '@/audio/target-structure';
+import { C_MAJOR, A_MINOR } from '../helpers/fixtures';
+import { midiToHz } from '@/audio/note-math';
+
+describe('buildTarget', () => {
+  it('returns a single note event for a scale degree in a key', () => {
+    const ev = buildTarget(C_MAJOR, 5, 'comfortable');
+    expect(typeof ev.midi).toBe('number');
+    expect(ev.durationSec).toBeCloseTo(TARGET_DURATION_SECONDS, 2);
+  });
+
+  it('degree 5 in C major equals G (MIDI 67) in octave 4', () => {
+    const ev = buildTarget(C_MAJOR, 5, 'comfortable');
+    expect(ev.midi).toBe(67);
+    expect(midiToHz(ev.midi)).toBeCloseTo(391.995, 1);
+  });
+
+  it('degree 3 in A minor equals C (MIDI 60) in octave 4', () => {
+    const ev = buildTarget(A_MINOR, 3, 'comfortable');
+    expect(ev.midi).toBe(60);
+  });
+
+  it('narrow register stays within one octave above tonic', () => {
+    for (const d of [1, 2, 3, 4, 5, 6, 7] as const) {
+      const ev = buildTarget(C_MAJOR, d, 'narrow');
+      // Tonic in narrow mode = C4 = 60. Max: B4 = 71.
+      expect(ev.midi).toBeGreaterThanOrEqual(60);
+      expect(ev.midi).toBeLessThanOrEqual(71);
+    }
+  });
+
+  it('wide register can span below tonic', () => {
+    // With 'wide', we expect at least one degree to fall below octave-4 tonic for some keys.
+    // For C major degree 1 wide, the target may be C3 = 48 or C4 = 60. Just verify the range span.
+    const picks = [1, 2, 3, 4, 5, 6, 7].map((d) =>
+      buildTarget(C_MAJOR, d as 1|2|3|4|5|6|7, 'wide').midi,
+    );
+    const min = Math.min(...picks);
+    const max = Math.max(...picks);
+    expect(max - min).toBeGreaterThan(0); // non-zero range
+    expect(max).toBeLessThan(84); // nothing above C6
+    expect(min).toBeGreaterThan(36); // nothing below C2
+  });
+
+  it('target hz matches the midi output', () => {
+    const ev = buildTarget(C_MAJOR, 5, 'comfortable');
+    expect(ev.hz).toBeCloseTo(midiToHz(ev.midi), 2);
+  });
+});

--- a/tests/audio/target-structure.test.ts
+++ b/tests/audio/target-structure.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildTarget, TARGET_DURATION_SECONDS } from '@/audio/target-structure';
-import { C_MAJOR, A_MINOR } from '../helpers/fixtures';
-import { midiToHz } from '@/audio/note-math';
+import { C_MAJOR, A_MINOR, G_MAJOR } from '../helpers/fixtures';
+import { midiToHz, pitchClassToMidi } from '@/audio/note-math';
 
 describe('buildTarget', () => {
   it('returns a single note event for a scale degree in a key', () => {
@@ -16,17 +16,20 @@ describe('buildTarget', () => {
     expect(midiToHz(ev.midi)).toBeCloseTo(391.995, 1);
   });
 
-  it('degree 3 in A minor equals C (MIDI 60) in octave 4', () => {
+  it('degree 3 in A minor equals C5 (MIDI 72) — shifted above tonic A4=69', () => {
     const ev = buildTarget(A_MINOR, 3, 'comfortable');
-    expect(ev.midi).toBe(60);
+    expect(ev.midi).toBe(72);
   });
 
-  it('narrow register stays within one octave above tonic', () => {
-    for (const d of [1, 2, 3, 4, 5, 6, 7] as const) {
-      const ev = buildTarget(C_MAJOR, d, 'narrow');
-      // Tonic in narrow mode = C4 = 60. Max: B4 = 71.
-      expect(ev.midi).toBeGreaterThanOrEqual(60);
-      expect(ev.midi).toBeLessThanOrEqual(71);
+  it('narrow register stays within one octave above tonic (parametrized)', () => {
+    const keys = [C_MAJOR, G_MAJOR, A_MINOR];
+    for (const key of keys) {
+      const tonicMidi = pitchClassToMidi(key.tonic, 4);
+      for (const d of [1, 2, 3, 4, 5, 6, 7] as const) {
+        const ev = buildTarget(key, d, 'narrow');
+        expect(ev.midi).toBeGreaterThanOrEqual(tonicMidi);
+        expect(ev.midi).toBeLessThanOrEqual(tonicMidi + 12);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- Adds `src/audio/target-structure.ts`: pure `buildTarget(key, degree, register)` function that emits a `NoteEvent` (`{ midi, hz, durationSec }`) for a scale degree in a given key and register.
- Adds `tests/audio/target-structure.test.ts`: 6 tests covering basic shape, specific MIDI values for C major degree 5 and A minor degree 3, narrow register bounds, wide register span, and hz/midi consistency.
- `Register` sourced from `@/types/domain` (confirmed `'narrow' | 'comfortable' | 'wide'`). `semitoneOffset` from `@/types/music` (confirmed signature `(degree, quality)`).
- Implementation note: uses pitch-class arithmetic (tonic index + offset mod 12 → `pitchClassToMidi`) rather than raw semitone addition to tonic MIDI. This avoids octave-wrapping artefacts (e.g. A4+3 = C5, not C4). `narrow` and `comfortable` both use octave 4; `wide` drops even degrees to octave 3 for deterministic span.

## Test plan

- [x] `npm run test` — 104 → 110 (6 new tests, all passing)
- [x] `npm run typecheck` — exits 0
- [x] No Tone.js or audio imports; module is pure logic only
- [x] `narrow` register: all 7 degrees of C major land in [60, 71]
- [x] `comfortable` register: matches `narrow` (deferral documented in code)
- [x] `wide` register: span > 0, min > 36, max < 84