### PR TITLE
feat(pitch): Hz → scale-degree mapping (octave-invariant)

### DIFF
--- a/src/pitch/degree-mapping.ts
+++ b/src/pitch/degree-mapping.ts
@@ -1,0 +1,45 @@
+import type { Key, Degree } from '@/types/music';
+import { DEGREES, semitoneOffset } from '@/types/music';
+import { hzToMidi, pitchClassToMidi } from '@/audio/note-math';
+
+export interface DegreeMapping {
+  degree: Degree;
+  /** Signed cents deviation from the ideal pitch of that degree in the current key. */
+  cents: number;
+  /** True if |cents| < IN_KEY_CENTS (the pitch sits on a diatonic degree). */
+  inKey: boolean;
+}
+
+/** Pitch must be within this cents range of a diatonic degree to count as "in key". */
+const IN_KEY_CENTS = 50;
+
+/**
+ * Map a detected Hz to the nearest diatonic scale degree in the given key,
+ * octave-invariant. Returns null if `hz` is not positive.
+ */
+export function mapHzToDegree(hz: number, key: Key): DegreeMapping | null {
+  if (hz <= 0) return null;
+
+  const sungMidi = hzToMidi(hz);
+  const tonicMidi = pitchClassToMidi(key.tonic, 4);
+  // Pitch-class distance mod 12 from tonic. Negative rounding-safe.
+  const sungPcFromTonic = ((sungMidi - tonicMidi) % 12 + 12) % 12;
+
+  let best: { degree: Degree; cents: number } | null = null;
+  for (const d of DEGREES) {
+    const targetOffset = semitoneOffset(d, key.quality);
+    // Compare sungPcFromTonic to targetOffset, choosing the shorter circular distance.
+    let diff = sungPcFromTonic - targetOffset; // semitones
+    // Normalize to [-6, 6]
+    while (diff > 6) diff -= 12;
+    while (diff < -6) diff += 12;
+    const cents = diff * 100;
+    if (best === null || Math.abs(cents) < Math.abs(best.cents)) {
+      best = { degree: d, cents };
+    }
+  }
+
+  // best is always non-null because DEGREES has 7 entries
+  const { degree, cents } = best!;
+  return { degree, cents, inKey: Math.abs(cents) < IN_KEY_CENTS };
+}

--- a/tests/pitch/degree-mapping.test.ts
+++ b/tests/pitch/degree-mapping.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { mapHzToDegree } from '@/pitch/degree-mapping';
+import { C_MAJOR, A_MINOR } from '../helpers/fixtures';
+import { midiToHz, pitchClassToMidi } from '@/audio/note-math';
+
+describe('mapHzToDegree', () => {
+  it('exact C maps to degree 1 in C major', () => {
+    const hz = midiToHz(pitchClassToMidi('C', 4));
+    const r = mapHzToDegree(hz, C_MAJOR);
+    expect(r).not.toBe(null);
+    if (!r) return;
+    expect(r.degree).toBe(1);
+    expect(Math.abs(r.cents)).toBeLessThan(5);
+    expect(r.inKey).toBe(true);
+  });
+
+  it('exact G maps to degree 5 in C major (any octave)', () => {
+    const g3 = midiToHz(pitchClassToMidi('G', 3));
+    const g4 = midiToHz(pitchClassToMidi('G', 4));
+    const g5 = midiToHz(pitchClassToMidi('G', 5));
+    for (const hz of [g3, g4, g5]) {
+      const r = mapHzToDegree(hz, C_MAJOR);
+      expect(r).not.toBe(null);
+      if (!r) return;
+      expect(r.degree).toBe(5);
+      expect(r.inKey).toBe(true);
+    }
+  });
+
+  it('A in A minor maps to degree 1', () => {
+    const hz = midiToHz(pitchClassToMidi('A', 4));
+    const r = mapHzToDegree(hz, A_MINOR);
+    expect(r).not.toBe(null);
+    if (!r) return;
+    expect(r.degree).toBe(1);
+  });
+
+  it('C in A minor maps to degree 3 (minor third of A)', () => {
+    const hz = midiToHz(pitchClassToMidi('C', 5));
+    const r = mapHzToDegree(hz, A_MINOR);
+    expect(r).not.toBe(null);
+    if (!r) return;
+    expect(r.degree).toBe(3);
+  });
+
+  it('sharp pitch reports positive cents', () => {
+    const hz = midiToHz(pitchClassToMidi('G', 4)) * Math.pow(2, 20 / 1200); // +20 cents
+    const r = mapHzToDegree(hz, C_MAJOR);
+    expect(r).not.toBe(null);
+    if (!r) return;
+    expect(r.degree).toBe(5);
+    expect(r.cents).toBeGreaterThan(15);
+    expect(r.cents).toBeLessThan(25);
+  });
+
+  it('out-of-key pitch (F# in C major) maps to nearest degree (4 or 5) with inKey=false', () => {
+    const hz = midiToHz(pitchClassToMidi('F#', 4));
+    const r = mapHzToDegree(hz, C_MAJOR);
+    expect(r).not.toBe(null);
+    if (!r) return;
+    expect([4, 5]).toContain(r.degree);
+    expect(r.inKey).toBe(false);
+  });
+
+  it('returns null for non-positive hz', () => {
+    expect(mapHzToDegree(0, C_MAJOR)).toBe(null);
+    expect(mapHzToDegree(-1, C_MAJOR)).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Plan B Task 6: pure, octave-invariant Hz → scale-degree mapping.

- New module `src/pitch/degree-mapping.ts` — exports `mapHzToDegree(hz, key)` returning `{ degree, cents, inKey } | null`
- Octave-invariant: pitch-class distance mod 12 from tonic, then shortest circular distance to each diatonic degree's semitone offset
- `inKey = true` iff `|cents| < 50`; returns `null` for non-positive hz
- No audio dependencies — pure math only

## Test plan

- [x] `tests/pitch/degree-mapping.test.ts` — 7 new tests covering:
  - Exact C4 → degree 1 in C major (near-zero cents, inKey)
  - G3, G4, G5 all → degree 5 in C major (octave-invariance)
  - A4 → degree 1 in A minor; C5 → degree 3 in A minor
  - +20 cent sharp pitch → degree 5, cents in [15, 25]
  - F# (out-of-key) → degree 4 or 5, inKey=false
  - null for hz=0 and hz=-1
- [x] `npm run typecheck` exits 0
- [x] `npm run test` passes 122 tests (115 → 122)