### PR TITLE
feat(audio): Tone.js player for cadence + target round

### DIFF
--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -52,8 +52,7 @@ export function playRound(input: PlayRoundInput): PlayRoundHandle {
   for (const ev of input.cadence) {
     const at = now + ev.startSec;
     const hzs: number[] = ev.notes.map((m) => midiToHz(m));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (synth as any).triggerAttackRelease(hzs, ev.durationSec, at);
+    synth.triggerAttackRelease(hzs, ev.durationSec, at);
     lastCadenceEnd = Math.max(lastCadenceEnd, at + ev.durationSec);
   }
 
@@ -65,8 +64,7 @@ export function playRound(input: PlayRoundInput): PlayRoundHandle {
   const cancel = () => {
     cancelled = true;
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (synth as any).releaseAll?.();
+      synth.releaseAll();
       synth.disconnect();
       synth.dispose();
     } catch {

--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -1,0 +1,106 @@
+import * as Tone from 'tone';
+import type { ChordEvent } from './cadence-structure';
+import type { NoteEvent } from './target-structure';
+import { midiToHz } from './note-math';
+import { getTimbre, type TimbreId } from './timbres';
+
+/**
+ * Ensure Tone.js audio context is started. Must be called from a user
+ * gesture handler per browser autoplay policy.
+ */
+export async function ensureAudioContextStarted(): Promise<void> {
+  await Tone.start();
+}
+
+export interface PlayRoundInput {
+  timbreId: TimbreId;
+  cadence: ReadonlyArray<ChordEvent>;
+  target: NoteEvent;
+  /** Seconds of silence between cadence end and target start. */
+  gapSec?: number;
+}
+
+export interface PlayRoundHandle {
+  /** Promise that resolves when the target note has finished playing. */
+  done: Promise<void>;
+  /** Time (seconds, audio context time) at which the target note started. */
+  targetStartAtAcTime: Promise<number>;
+  /** Stop everything and dispose the synth. */
+  cancel: () => void;
+}
+
+/**
+ * Play a full round: the cadence chord sequence, then (after `gapSec`) the target note.
+ * Resolves when the target note finishes.
+ *
+ * No unit tests: Tone.js requires a real AudioContext and is not meaningfully
+ * testable in Vitest/jsdom. Integration coverage is provided by:
+ *   - Task 11: manual audio harness (harness/audio.html)
+ *   - Task 12: Playwright smoke test
+ */
+export function playRound(input: PlayRoundInput): PlayRoundHandle {
+  const gap = input.gapSec ?? 0.4;
+  const synth = getTimbre(input.timbreId).createSynth();
+  synth.toDestination();
+
+  const now = Tone.now();
+  let lastCadenceEnd = now;
+
+  // Schedule cadence chords.
+  // Tone.PolySynth.triggerAttackRelease accepts Frequency | Frequency[] where
+  // Frequency includes number (Hz), so number[] is a valid Frequency[].
+  for (const ev of input.cadence) {
+    const at = now + ev.startSec;
+    const hzs: number[] = ev.notes.map((m) => midiToHz(m));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (synth as any).triggerAttackRelease(hzs, ev.durationSec, at);
+    lastCadenceEnd = Math.max(lastCadenceEnd, at + ev.durationSec);
+  }
+
+  const targetAt = lastCadenceEnd + gap;
+  synth.triggerAttackRelease(midiToHz(input.target.midi), input.target.durationSec, targetAt);
+  const targetEnd = targetAt + input.target.durationSec;
+
+  let cancelled = false;
+  const cancel = () => {
+    cancelled = true;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (synth as any).releaseAll?.();
+      synth.disconnect();
+      synth.dispose();
+    } catch {
+      // swallow — disposal is best-effort
+    }
+  };
+
+  function waitUntil(acTime: number): Promise<void> {
+    return new Promise((resolve) => {
+      function check() {
+        if (cancelled) return resolve();
+        const remaining = acTime - Tone.now();
+        if (remaining <= 0) return resolve();
+        setTimeout(check, Math.max(10, Math.min(100, remaining * 1000)));
+      }
+      check();
+    });
+  }
+
+  const done = waitUntil(targetEnd + 0.05).then(() => {
+    // Auto-dispose after target completes so we do not leak synth instances.
+    if (!cancelled) {
+      try {
+        synth.disconnect();
+        synth.dispose();
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  return {
+    done,
+    targetStartAtAcTime: Promise.resolve(targetAt),
+    cancel,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `src/audio/player.ts` implementing the public API `ensureAudioContextStarted()` and `playRound(input)`.
- `playRound` schedules the full cadence chord sequence followed (after a configurable `gapSec`) by the target note, returning a `PlayRoundHandle` with `done` (promise resolving when target finishes), `targetStartAtAcTime` (promise), and `cancel`.
- Factory pattern: each call creates a fresh `PolySynth` via `getTimbre(id).createSynth()` and auto-disposes it on completion or cancellation — no synth instance outlives a round.
- `ensureAudioContextStarted` delegates to `Tone.start()` and must be called from a user gesture handler; `playRound` assumes the context is already started.

## No unit tests — by design

Tone.js touches `AudioContext` at construction time and requires a real audio context to schedule events; unit-testing it in Vitest/jsdom with meaningful assertions would require either a full Web Audio mock (a maintenance trap) or assertions that don't actually verify audio output (not useful). This is documented in the project's testing philosophy:

> Audio playback, mic input, ML inference: NOT unit-tested. Covered by the dev harness (Plan B task 11) and a single Playwright smoke test (Plan B task 12). Do not chase 100% unit coverage of Web Audio — it's a mocking trap.

Integration coverage is provided by:
- **Task 11** — manual audio harness at `harness/audio.html` (exercises the full playRound path in a real browser)
- **Task 12** — Playwright smoke test (`npm run test:e2e`)

## TypeScript adjustments

- The chord-loop `triggerAttackRelease` call (passing `number[]` for multi-note chords) uses a narrow `(synth as any)` cast. Tone's `PolySynth.triggerAttackRelease` is typed as `Frequency | Frequency[]` where `Frequency` includes `number` (Hz), so `number[]` is semantically correct — but TypeScript's overload resolution sometimes fails to unify the `number[]` literal with `Frequency[]` under strict mode. The cast is isolated to this one call and documented inline.
- `releaseAll` is called via `(synth as any).releaseAll?.()` (optional chaining) in `cancel()` since some Tone versions may not expose it on `PolySynth`; the `?.` makes the call safe regardless.
- The `waitUntil` inner loop uses `function check()` declaration instead of an arrow `const check = () => ...` to satisfy the declaration-before-use rule in the recursive `setTimeout` closure.

## Test plan

- [x] `npm run typecheck` exits 0
- [x] `npm run test` still passes all 122 existing tests (no new tests in this task)
- [ ] Manual: `npm run dev`, open harness once Task 11 lands, verify audio plays
- [ ] Automated: `npm run test:e2e` once Task 12 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)