### PR TITLE
feat(pitch): YIN AudioWorklet + main-thread facade

### DIFF
--- a/src/pitch/pitch-detector.ts
+++ b/src/pitch/pitch-detector.ts
@@ -1,0 +1,58 @@
+export interface PitchFrame {
+  hz: number;
+  confidence: number;
+  /** Timestamp in AudioContext time (seconds). */
+  at: number;
+}
+
+export interface PitchDetectorHandle {
+  stop: () => Promise<void>;
+  /** Observable of pitch frames. Returns unsubscribe fn. */
+  subscribe: (cb: (frame: PitchFrame) => void) => () => void;
+}
+
+export interface StartPitchDetectorInput {
+  audioContext: AudioContext;
+  micStream: MediaStream;
+}
+
+/**
+ * Start pitch detection on a mic stream. Caller owns the AudioContext and
+ * MediaStream lifetimes.
+ */
+export async function startPitchDetector(
+  input: StartPitchDetectorInput,
+): Promise<PitchDetectorHandle> {
+  const { audioContext, micStream } = input;
+
+  // Load the worklet module. Vite resolves this URL at build time so the
+  // worklet script is bundled as a separate chunk / asset.
+  const workletUrl = new URL('./yin-worklet.ts', import.meta.url);
+  await audioContext.audioWorklet.addModule(workletUrl.href);
+
+  const source = audioContext.createMediaStreamSource(micStream);
+  const node = new AudioWorkletNode(audioContext, 'yin-processor');
+
+  source.connect(node);
+  // Worklet output is intentionally NOT routed to destination — analysis only.
+
+  const subscribers = new Set<(f: PitchFrame) => void>();
+
+  node.port.onmessage = (ev: MessageEvent<PitchFrame>) => {
+    const frame = ev.data;
+    for (const cb of subscribers) cb(frame);
+  };
+
+  return {
+    subscribe(cb) {
+      subscribers.add(cb);
+      // subscribers.delete returns boolean; wrap in void to match () => void.
+      return () => { subscribers.delete(cb); };
+    },
+    async stop() {
+      source.disconnect();
+      node.port.onmessage = null;
+      node.disconnect();
+    },
+  };
+}

--- a/src/pitch/yin-worklet.ts
+++ b/src/pitch/yin-worklet.ts
@@ -33,6 +33,10 @@ class YinProcessor extends AudioWorkletProcessor {
   private writePos = 0;
   private sr: number;
   private quantumCount = 0;
+  private samplesWritten = 0;
+  // Preallocated chronological unwrap scratch — reused every call to avoid
+  // per-quantum allocations on the audio render thread (GC pauses → glitches).
+  private readonly scratch: Float32Array = new Float32Array(2048);
 
   constructor() {
     super();
@@ -50,6 +54,12 @@ class YinProcessor extends AudioWorkletProcessor {
       this.buf[this.writePos] = input[i]!;
       this.writePos = (this.writePos + 1) % this.buf.length;
     }
+    this.samplesWritten += input.length;
+
+    // Skip YIN analysis until the ring buffer has been filled at least once;
+    // otherwise the chronological unwrap produces a [zeros | real] seam that
+    // slips past YIN's RMS guard and emits bogus pitch frames for ~320 ms.
+    if (this.samplesWritten < this.buf.length) return true;
 
     // Throttle YIN analysis to once every 8 render quanta (~47 Hz updates).
     // Lower than sample rate but plenty for UI feedback; keeps audio-thread
@@ -61,11 +71,11 @@ class YinProcessor extends AudioWorkletProcessor {
     // The ring buffer's sample at this.writePos is the OLDEST (next to be overwritten),
     // and the sample at this.writePos - 1 (mod length) is the NEWEST. So chronological
     // order is [writePos..end] followed by [0..writePos].
-    const scratch = new Float32Array(this.buf.length);
+    // set() overwrites every index in this.scratch so no zero-reset is needed.
     const tail = this.buf.length - this.writePos;
-    scratch.set(this.buf.subarray(this.writePos), 0);
-    scratch.set(this.buf.subarray(0, this.writePos), tail);
-    const { hz, confidence } = detectPitch(scratch, this.sr);
+    this.scratch.set(this.buf.subarray(this.writePos), 0);
+    this.scratch.set(this.buf.subarray(0, this.writePos), tail);
+    const { hz, confidence } = detectPitch(this.scratch, this.sr);
     // currentTime is declared above as a worklet global (AudioWorkletGlobalScope)
     this.port.postMessage({ hz, confidence, at: currentTime });
     return true;

--- a/src/pitch/yin-worklet.ts
+++ b/src/pitch/yin-worklet.ts
@@ -1,0 +1,62 @@
+/// <reference lib="WebWorker" />
+// AudioWorklet global scope — not the main thread.
+//
+// TypeScript type approach: AudioWorkletProcessor, registerProcessor, and
+// currentTime are globals that exist only in the AudioWorkletGlobalScope.
+// TypeScript's standard libs (even lib.webworker.d.ts) do not declare them as
+// of TS 5.6. Rather than adding "WebWorker" to tsconfig.json (which would
+// redefine DOM globals like MessageEvent and break other project files), we
+// declare the missing types inline here. The triple-slash directive above
+// provides the DedicatedWorkerGlobalScope baseline. Runtime correctness is
+// verified by the manual harness (Task 11) and the Playwright smoke test
+// (Task 12).
+
+import { detectPitch } from './yin';
+
+// Minimal declarations for AudioWorklet globals absent from TS standard libs.
+declare class AudioWorkletProcessor {
+  readonly port: MessagePort;
+  constructor();
+  process(
+    inputs: Float32Array[][],
+    outputs: Float32Array[][],
+    parameters: Record<string, Float32Array>,
+  ): boolean;
+}
+declare function registerProcessor(name: string, ctor: unknown): void;
+declare const currentTime: number;
+declare const sampleRate: number;
+
+class YinProcessor extends AudioWorkletProcessor {
+  // ring buffer of samples
+  private buf: Float32Array = new Float32Array(2048);
+  private writePos = 0;
+  private sr: number;
+
+  constructor() {
+    super();
+    // sampleRate is declared above as a worklet global (AudioWorkletGlobalScope)
+    this.sr = sampleRate;
+  }
+
+  override process(inputs: Float32Array[][]): boolean {
+    const input = inputs[0]?.[0];
+    if (!input) return true;
+
+    // Write incoming samples into ring buffer — single-producer from process(),
+    // no threading hazard.
+    for (let i = 0; i < input.length; i++) {
+      this.buf[this.writePos] = input[i]!;
+      this.writePos = (this.writePos + 1) % this.buf.length;
+    }
+
+    // Run YIN detection on the full 2048-sample ring buffer every render quantum.
+    // For future performance tuning, this could be throttled to once per N quanta.
+    const { hz, confidence } = detectPitch(this.buf, this.sr);
+    // currentTime is declared above as a worklet global (AudioWorkletGlobalScope)
+    this.port.postMessage({ hz, confidence, at: currentTime });
+    return true;
+  }
+}
+
+registerProcessor('yin-processor', YinProcessor);

--- a/src/pitch/yin-worklet.ts
+++ b/src/pitch/yin-worklet.ts
@@ -32,6 +32,7 @@ class YinProcessor extends AudioWorkletProcessor {
   private buf: Float32Array = new Float32Array(2048);
   private writePos = 0;
   private sr: number;
+  private quantumCount = 0;
 
   constructor() {
     super();
@@ -50,9 +51,21 @@ class YinProcessor extends AudioWorkletProcessor {
       this.writePos = (this.writePos + 1) % this.buf.length;
     }
 
-    // Run YIN detection on the full 2048-sample ring buffer every render quantum.
-    // For future performance tuning, this could be throttled to once per N quanta.
-    const { hz, confidence } = detectPitch(this.buf, this.sr);
+    // Throttle YIN analysis to once every 8 render quanta (~47 Hz updates).
+    // Lower than sample rate but plenty for UI feedback; keeps audio-thread
+    // CPU bounded.
+    this.quantumCount++;
+    if (this.quantumCount % 8 !== 0) return true;
+
+    // Unwrap ring buffer into chronological scratch array before YIN.
+    // The ring buffer's sample at this.writePos is the OLDEST (next to be overwritten),
+    // and the sample at this.writePos - 1 (mod length) is the NEWEST. So chronological
+    // order is [writePos..end] followed by [0..writePos].
+    const scratch = new Float32Array(this.buf.length);
+    const tail = this.buf.length - this.writePos;
+    scratch.set(this.buf.subarray(this.writePos), 0);
+    scratch.set(this.buf.subarray(0, this.writePos), tail);
+    const { hz, confidence } = detectPitch(scratch, this.sr);
     // currentTime is declared above as a worklet global (AudioWorkletGlobalScope)
     this.port.postMessage({ hz, confidence, at: currentTime });
     return true;


### PR DESCRIPTION
## Summary

Implements Plan B Task 8: a YIN AudioWorklet processor and a main-thread facade that wraps it as a subscribe-able event stream.

**New files:**
- `src/pitch/yin-worklet.ts` — `YinProcessor extends AudioWorkletProcessor`; runs YIN on every 2048-sample ring buffer from the mic, posts `{ hz, confidence, at }` frames via `MessagePort`.
- `src/pitch/pitch-detector.ts` — `startPitchDetector()` loads the worklet module, wires a `MediaStreamSource → AudioWorkletNode` graph (analysis-only, not routed to destination), and returns a `PitchDetectorHandle` with `subscribe` / `stop`.

## No unit tests

AudioWorklet requires a real `AudioContext`, which is unavailable in jsdom/Node. These modules are intentionally excluded from the Vitest suite. Runtime correctness will be verified by the dev harness (Task 11) and the Playwright smoke test (Task 12), per the plan's testing philosophy.

## TypeScript / tsconfig approach (option 1 variant)

`AudioWorkletProcessor`, `registerProcessor`, `currentTime`, and `sampleRate` are globals that exist only in `AudioWorkletGlobalScope`. TypeScript 5.6's standard libs — including `lib.webworker.d.ts` — do **not** declare them.

Two options were available:
1. Add `"WebWorker"` to `tsconfig.json` lib.
2. Declare the missing types inline in the worklet file.

**Option 1 (adding `"WebWorker"` to tsconfig) was rejected** because `lib.webworker.d.ts` redefines DOM globals (e.g. `Event`, `MessageEvent`, `setTimeout`) in ways that conflict with `lib.dom.d.ts` and would break type-checking across the rest of the project.

**Chosen approach: inline `declare` statements in `yin-worklet.ts`** — `declare class AudioWorkletProcessor`, `declare function registerProcessor`, `declare const currentTime`, `declare const sampleRate`. This scopes the type augmentation to this one file with zero global side-effects. The file also carries a `/// <reference lib="WebWorker" />` directive for the `DedicatedWorkerGlobalScope` baseline. No `tsconfig.json` was modified.

The file does **not** use `// @ts-nocheck`.

## Other TypeScript adjustments

- Added `override` keyword to `YinProcessor.process()` — required by the project's `noImplicitOverride: true` tsconfig flag.
- `subscribe` return value: `() => { subscribers.delete(cb); }` wraps the `Set.delete` boolean return in a void block to satisfy the `() => void` contract.

## Verification

```
npm run typecheck  # exit 0
npm run test       # 122/122 passing (no new tests added)
```