### PR TITLE
feat(mic): permission helper

### DIFF
--- a/src/mic/permission.ts
+++ b/src/mic/permission.ts
@@ -1,0 +1,57 @@
+export type MicPermissionState =
+  | 'unknown'
+  | 'prompt'
+  | 'granted'
+  | 'denied'
+  | 'unavailable';
+
+export interface MicStreamHandle {
+  stream: MediaStream;
+  stop: () => void;
+}
+
+/**
+ * Request mic access. Returns a MediaStream if granted; throws on denial/unavailability.
+ * The caller is responsible for calling `stop()` when done to release the mic.
+ */
+export async function requestMicStream(): Promise<MicStreamHandle> {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+    const e = new Error('Microphone API unavailable in this browser');
+    (e as Error & { code?: string }).code = 'unavailable';
+    throw e;
+  }
+
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: false, // we care about pitch, not loudness
+      channelCount: 1,
+    },
+    video: false,
+  });
+
+  return {
+    stream,
+    stop() {
+      for (const t of stream.getTracks()) t.stop();
+    },
+  };
+}
+
+/**
+ * Query the current mic permission state without prompting.
+ * Not supported on all browsers — falls back to 'unknown'.
+ */
+export async function queryMicPermission(): Promise<MicPermissionState> {
+  try {
+    // @ts-expect-error - Permissions.query with 'microphone' is non-standard in some TS lib versions
+    const status = await navigator.permissions.query({ name: 'microphone' });
+    if (status.state === 'granted') return 'granted';
+    if (status.state === 'denied') return 'denied';
+    if (status.state === 'prompt') return 'prompt';
+  } catch {
+    // Some browsers (Safari) lack Permissions API for microphone.
+  }
+  return 'unknown';
+}


### PR DESCRIPTION
## Summary

- Adds `src/mic/permission.ts` with two exports:
  - `requestMicStream()` — calls `getUserMedia` with pitch-optimised constraints (`echoCancellation: true`, `noiseSuppression: true`, `autoGainControl: false`, `channelCount: 1`); throws with `code: 'unavailable'` if the API is absent; returns a `MicStreamHandle` where the caller owns `stop()`.
  - `queryMicPermission()` — queries the Permissions API for `'microphone'` state; falls back to `'unknown'` on browsers (Safari) that don't support it.
- `autoGainControl: false` is intentional — pitch detection needs amplitude intact, not loudness-normalised.

## Why no unit tests

`getUserMedia` and the Permissions API are not simulated by jsdom in any meaningful way — mocking them produces tests that verify the mock, not the code. Per the project's testing philosophy (see CLAUDE.md), audio I/O modules are covered by the manual dev harness (Plan B Task 11) and the Playwright smoke test (Plan B Task 12). Unit-testing this module would be a mocking trap.

## Notes

- The `@ts-expect-error` directive on `permissions.query({ name: 'microphone' })` is **kept**: the current TypeScript DOM lib defines `PermissionName` as `"geolocation" | "notifications" | "persistent-storage" | "push" | "screen-wake-lock" | "xr-spatial-tracking"` — `'microphone'` is absent, so the directive is necessary and tsc would error without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)