### PR TITLE
feat(harness): dev harness for manual audio validation

### DIFF
--- a/public/harness/audio.html
+++ b/public/harness/audio.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Audio Harness · ear-training-station</title>
+    <style>
+      :root { color-scheme: dark; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif;
+        background: #0a0a0a; color: #fafafa;
+        margin: 0; padding: 24px;
+        max-width: 720px; margin-inline: auto;
+      }
+      h1 { font-weight: 800; letter-spacing: -0.02em; font-size: 20px; }
+      h2 { font-size: 12px; letter-spacing: 0.2em; text-transform: uppercase; color: #737373; font-weight: 700; margin-top: 32px; }
+      .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin: 8px 0; }
+      button { background: #22d3ee; color: #0a0a0a; border: 0; padding: 10px 14px; border-radius: 6px; font-weight: 700; cursor: pointer; }
+      button[disabled] { opacity: 0.4; cursor: not-allowed; }
+      button.secondary { background: #171717; color: #fafafa; border: 1px solid #262626; }
+      select, input[type="number"] { background: #171717; color: #fafafa; border: 1px solid #262626; border-radius: 6px; padding: 8px; font-family: inherit; }
+      .log { background: #0f0f0f; border: 1px solid #171717; border-radius: 6px; padding: 12px; font-family: ui-monospace, monospace; font-size: 11px; white-space: pre-wrap; max-height: 300px; overflow: auto; }
+      .kv { display: grid; grid-template-columns: max-content 1fr; gap: 6px 12px; font-family: ui-monospace, monospace; font-size: 12px; }
+      .kv .k { color: #737373; letter-spacing: 0.1em; text-transform: uppercase; font-size: 10px; align-self: center; }
+      .kv .v { color: #22d3ee; }
+      .kv .v.amber { color: #fbbf24; }
+      .kv .v.red { color: #ef4444; }
+    </style>
+  </head>
+  <body>
+    <h1>Audio Harness</h1>
+
+    <h2>Playback</h2>
+    <div class="row">
+      <label>Timbre <select id="timbre"></select></label>
+      <label>Key <select id="key"></select></label>
+      <label>Degree <select id="degree"></select></label>
+      <label>Register <select id="register">
+        <option>narrow</option><option selected>comfortable</option><option>wide</option>
+      </select></label>
+      <button id="play">Play round</button>
+    </div>
+
+    <h2>Mic — Pitch</h2>
+    <div class="row">
+      <button id="start-pitch">Start pitch detection</button>
+      <button id="stop-pitch" class="secondary" disabled>Stop</button>
+    </div>
+    <div class="kv">
+      <div class="k">Hz</div><div id="pitch-hz" class="v">—</div>
+      <div class="k">Degree</div><div id="pitch-degree" class="v">—</div>
+      <div class="k">Cents</div><div id="pitch-cents" class="v">—</div>
+      <div class="k">Confidence</div><div id="pitch-conf" class="v">—</div>
+    </div>
+
+    <h2>Mic — Digit</h2>
+    <div class="row">
+      <button id="start-kws">Start digit recognizer</button>
+      <button id="stop-kws" class="secondary" disabled>Stop</button>
+    </div>
+    <div class="kv">
+      <div class="k">Digit</div><div id="kws-digit" class="v amber">—</div>
+      <div class="k">Confidence</div><div id="kws-conf" class="v">—</div>
+    </div>
+
+    <h2>Log</h2>
+    <div id="log" class="log"></div>
+
+    <script type="module" src="/src/harness/audio-harness.ts"></script>
+  </body>
+</html>

--- a/src/harness/audio-harness.ts
+++ b/src/harness/audio-harness.ts
@@ -1,3 +1,4 @@
+import * as Tone from 'tone';
 import { TIMBRE_IDS, type TimbreId } from '@/audio/timbres';
 import { DEGREES, type Degree, type PitchClass, type Key, type KeyQuality } from '@/types/music';
 import { buildCadence } from '@/audio/cadence-structure';
@@ -149,9 +150,10 @@ startPitchBtn.addEventListener('click', async () => {
   try {
     log('Requesting mic access for pitch detection…');
     micHandle = await requestMicStream();
-    const audioContext = new AudioContext();
+    // Reuse Tone's AudioContext so repeated Start/Stop cycles don't exhaust Chromium's ~6 concurrent-context limit.
+    const ac = Tone.getContext().rawContext as AudioContext;
     pitchDetector = await startPitchDetector({
-      audioContext,
+      audioContext: ac,
       micStream: micHandle.stream,
     });
 
@@ -184,12 +186,14 @@ startPitchBtn.addEventListener('click', async () => {
     el('pitch-hz').textContent = 'error';
     el('pitch-hz').classList.add('red');
 
-    // Clean up any partial state.
-    micHandle?.stop();
-    micHandle = null;
+    // Stop any partially-initialized handles before nulling to avoid leaks.
+    try { await pitchDetector?.stop(); } catch { /* ignore cleanup errors */ }
+    try { micHandle?.stop(); } catch { /* ignore cleanup errors */ }
     pitchDetector = null;
+    micHandle = null;
     pitchRunning = false;
     startPitchBtn.disabled = false;
+    stopPitchBtn.disabled = true;
   }
 });
 
@@ -254,9 +258,12 @@ startKwsBtn.addEventListener('click', async () => {
     log(`Digit recognizer error: ${msg}`);
     el('kws-digit').textContent = 'error';
 
+    // Stop any partially-initialized handle before nulling to avoid leaks.
+    try { await kwsHandle?.stop(); } catch { /* ignore cleanup errors */ }
     kwsHandle = null;
     kwsRunning = false;
     startKwsBtn.disabled = false;
+    stopKwsBtn.disabled = true;
   }
 });
 

--- a/src/harness/audio-harness.ts
+++ b/src/harness/audio-harness.ts
@@ -148,6 +148,7 @@ startPitchBtn.addEventListener('click', async () => {
   startPitchBtn.disabled = true;
 
   try {
+    await ensureAudioContextStarted();
     log('Requesting mic access for pitch detection…');
     micHandle = await requestMicStream();
     // Reuse Tone's AudioContext so repeated Start/Stop cycles don't exhaust Chromium's ~6 concurrent-context limit.

--- a/src/harness/audio-harness.ts
+++ b/src/harness/audio-harness.ts
@@ -1,0 +1,279 @@
+import { TIMBRE_IDS, type TimbreId } from '@/audio/timbres';
+import { DEGREES, type Degree, type PitchClass, type Key, type KeyQuality } from '@/types/music';
+import { buildCadence } from '@/audio/cadence-structure';
+import { buildTarget } from '@/audio/target-structure';
+import { ensureAudioContextStarted, playRound } from '@/audio/player';
+import { requestMicStream } from '@/mic/permission';
+import { startPitchDetector, type PitchDetectorHandle } from '@/pitch/pitch-detector';
+import { mapHzToDegree } from '@/pitch/degree-mapping';
+import { startKeywordSpotter, type KeywordSpotterHandle } from '@/speech/keyword-spotter';
+import type { Register } from '@/types/domain';
+
+// ---------------------------------------------------------------------------
+// DOM helpers — fail loudly if an element is missing so bugs surface in dev
+// ---------------------------------------------------------------------------
+
+function el<T extends HTMLElement>(id: string): T {
+  const node = document.getElementById(id);
+  if (!node) throw new Error(`#${id} not found`);
+  return node as T;
+}
+
+function setHTML(id: string, html: string): void {
+  el(id).textContent = html;
+}
+
+// ---------------------------------------------------------------------------
+// Log
+// ---------------------------------------------------------------------------
+
+const logEl = el<HTMLDivElement>('log');
+
+function log(msg: string): void {
+  const ts = new Date().toLocaleTimeString('en-US', { hour12: false });
+  logEl.textContent = `[${ts}] ${msg}\n` + (logEl.textContent ?? '');
+}
+
+// ---------------------------------------------------------------------------
+// Populate selects
+// ---------------------------------------------------------------------------
+
+const TONICS: PitchClass[] = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+const QUALITIES: KeyQuality[] = ['major', 'minor'];
+
+const timbreSel = el<HTMLSelectElement>('timbre');
+const keySel = el<HTMLSelectElement>('key');
+const degreeSel = el<HTMLSelectElement>('degree');
+const registerSel = el<HTMLSelectElement>('register');
+
+for (const id of TIMBRE_IDS) {
+  const opt = document.createElement('option');
+  opt.value = id;
+  opt.textContent = id;
+  timbreSel.appendChild(opt);
+}
+
+for (const tonic of TONICS) {
+  for (const quality of QUALITIES) {
+    const opt = document.createElement('option');
+    opt.value = `${tonic}-${quality}`;
+    opt.textContent = `${tonic} ${quality}`;
+    if (tonic === 'C' && quality === 'major') opt.selected = true;
+    keySel.appendChild(opt);
+  }
+}
+
+for (const d of DEGREES) {
+  const opt = document.createElement('option');
+  opt.value = String(d);
+  opt.textContent = String(d);
+  if (d === 1) opt.selected = true;
+  degreeSel.appendChild(opt);
+}
+
+// ---------------------------------------------------------------------------
+// Typed read helpers — no `as any`
+// ---------------------------------------------------------------------------
+
+function readTimbre(): TimbreId {
+  return timbreSel.value as TimbreId;
+}
+
+function readKey(): Key {
+  const parts = keySel.value.split('-');
+  return {
+    tonic: parts[0] as PitchClass,
+    quality: parts[1] as KeyQuality,
+  };
+}
+
+function readDegree(): Degree {
+  return Number(degreeSel.value) as Degree;
+}
+
+function readRegister(): Register {
+  return registerSel.value as Register;
+}
+
+// ---------------------------------------------------------------------------
+// Playback section
+// ---------------------------------------------------------------------------
+
+const playBtn = el<HTMLButtonElement>('play');
+
+playBtn.addEventListener('click', async () => {
+  await ensureAudioContextStarted();
+  const key = readKey();
+  const degree = readDegree();
+  const register = readRegister();
+  const timbreId = readTimbre();
+
+  const cadence = buildCadence(key);
+  const target = buildTarget(key, degree, register);
+
+  log(`Playing round — timbre:${timbreId} key:${keySel.value} degree:${degree} register:${register}`);
+
+  const handle = playRound({ timbreId, cadence, target });
+  playBtn.disabled = true;
+  try {
+    await handle.done;
+    log('Round complete.');
+  } catch (err) {
+    log(`Playback error: ${String(err)}`);
+  } finally {
+    playBtn.disabled = false;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Pitch detection section
+// ---------------------------------------------------------------------------
+
+const startPitchBtn = el<HTMLButtonElement>('start-pitch');
+const stopPitchBtn = el<HTMLButtonElement>('stop-pitch');
+
+let pitchDetector: PitchDetectorHandle | null = null;
+let micHandle: { stream: MediaStream; stop: () => void } | null = null;
+let pitchRunning = false; // re-entrancy guard
+
+startPitchBtn.addEventListener('click', async () => {
+  // Re-entrancy guard: if already running, do nothing.
+  if (pitchRunning) {
+    log('Pitch detection already running.');
+    return;
+  }
+
+  pitchRunning = true;
+  startPitchBtn.disabled = true;
+
+  try {
+    log('Requesting mic access for pitch detection…');
+    micHandle = await requestMicStream();
+    const audioContext = new AudioContext();
+    pitchDetector = await startPitchDetector({
+      audioContext,
+      micStream: micHandle.stream,
+    });
+
+    pitchDetector.subscribe((frame) => {
+      setHTML('pitch-hz', frame.hz > 0 ? frame.hz.toFixed(1) : '—');
+      setHTML('pitch-conf', (frame.confidence * 100).toFixed(0) + '%');
+
+      if (frame.hz > 0) {
+        const mapping = mapHzToDegree(frame.hz, readKey());
+        if (mapping) {
+          setHTML('pitch-degree', String(mapping.degree));
+          const sign = mapping.cents >= 0 ? '+' : '';
+          setHTML('pitch-cents', `${sign}${mapping.cents.toFixed(0)}¢`);
+        } else {
+          setHTML('pitch-degree', '—');
+          setHTML('pitch-cents', '—');
+        }
+      } else {
+        setHTML('pitch-degree', '—');
+        setHTML('pitch-cents', '—');
+      }
+    });
+
+    stopPitchBtn.disabled = false;
+    log('Pitch detection started.');
+  } catch (err) {
+    // Permission denied or other error: show it and restore start button.
+    const msg = err instanceof Error ? err.message : String(err);
+    log(`Pitch detection error: ${msg}`);
+    el('pitch-hz').textContent = 'error';
+    el('pitch-hz').classList.add('red');
+
+    // Clean up any partial state.
+    micHandle?.stop();
+    micHandle = null;
+    pitchDetector = null;
+    pitchRunning = false;
+    startPitchBtn.disabled = false;
+  }
+});
+
+stopPitchBtn.addEventListener('click', async () => {
+  stopPitchBtn.disabled = true;
+  try {
+    await pitchDetector?.stop();
+    micHandle?.stop();
+  } catch (err) {
+    log(`Stop pitch error: ${String(err)}`);
+  } finally {
+    pitchDetector = null;
+    micHandle = null;
+    pitchRunning = false;
+    startPitchBtn.disabled = false;
+    setHTML('pitch-hz', '—');
+    setHTML('pitch-degree', '—');
+    setHTML('pitch-cents', '—');
+    setHTML('pitch-conf', '—');
+    el('pitch-hz').classList.remove('red');
+    log('Pitch detection stopped.');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Keyword spotter section
+// ---------------------------------------------------------------------------
+
+const startKwsBtn = el<HTMLButtonElement>('start-kws');
+const stopKwsBtn = el<HTMLButtonElement>('stop-kws');
+
+let kwsHandle: KeywordSpotterHandle | null = null;
+let kwsRunning = false; // re-entrancy guard
+
+startKwsBtn.addEventListener('click', async () => {
+  // Re-entrancy guard: if already running, do nothing.
+  if (kwsRunning) {
+    log('Digit recognizer already running.');
+    return;
+  }
+
+  kwsRunning = true;
+  startKwsBtn.disabled = true;
+
+  try {
+    log('Loading digit recognizer (first load may take a moment)…');
+    kwsHandle = await startKeywordSpotter({ probabilityThreshold: 0.75, minConfidence: 0.75 });
+
+    kwsHandle.subscribe((frame) => {
+      if (frame.digit !== null) {
+        setHTML('kws-digit', frame.digit);
+        setHTML('kws-conf', (frame.confidence * 100).toFixed(0) + '%');
+        log(`Digit heard: "${frame.digit}" (${(frame.confidence * 100).toFixed(0)}%)`);
+      }
+    });
+
+    stopKwsBtn.disabled = false;
+    log('Digit recognizer started.');
+  } catch (err) {
+    // Permission denied or model load failure: show it and restore start button.
+    const msg = err instanceof Error ? err.message : String(err);
+    log(`Digit recognizer error: ${msg}`);
+    el('kws-digit').textContent = 'error';
+
+    kwsHandle = null;
+    kwsRunning = false;
+    startKwsBtn.disabled = false;
+  }
+});
+
+stopKwsBtn.addEventListener('click', async () => {
+  stopKwsBtn.disabled = true;
+  try {
+    await kwsHandle?.stop();
+  } catch (err) {
+    log(`Stop KWS error: ${String(err)}`);
+  } finally {
+    kwsHandle = null;
+    kwsRunning = false;
+    startKwsBtn.disabled = false;
+    setHTML('kws-digit', '—');
+    setHTML('kws-conf', '—');
+    log('Digit recognizer stopped.');
+  }
+});
+
+log('Harness ready.');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,6 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { fileURLToPath } from 'node:url';
-import { resolve } from 'node:path';
-
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export default defineConfig({
   plugins: [svelte()],
@@ -14,13 +11,5 @@ export default defineConfig({
   },
   server: {
     port: 5173,
-  },
-  build: {
-    rollupOptions: {
-      input: {
-        main: resolve(__dirname, 'index.html'),
-        harness: resolve(__dirname, 'public/harness/audio.html'),
-      },
-    },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export default defineConfig({
   plugins: [svelte()],
@@ -11,5 +14,13 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        harness: resolve(__dirname, 'public/harness/audio.html'),
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

- Adds `public/harness/audio.html` — dark-themed standalone page (plain HTML, no Svelte) served at `http://localhost:5173/harness/audio.html` in dev.
- Adds `src/harness/audio-harness.ts` — TypeScript module that wires every Plan B module together: timbre/key/degree/register selects drive `playRound`, two mic panels expose pitch detection (with live Hz / degree / cents display) and digit keyword spotting.
- Updates `vite.config.ts` to register the harness as a second Rollup entry point (`harness`) so `npm run build` includes it alongside `main`.

## What the harness exposes

| Section | What you can do |
|---|---|
| Playback | Pick timbre, key, degree, register → click **Play round** to hear cadence + target note |
| Mic — Pitch | Start YIN pitch detector; see live Hz, nearest scale degree, cents deviation |
| Mic — Digit | Start TF.js Speech Commands keyword spotter; spoken digit + confidence appear in real time |
| Log | Timestamped event log covering round start/stop, errors, detected digits |

## Deferred items addressed

- **Re-entrancy guards** — both Start buttons use a boolean guard (`pitchRunning` / `kwsRunning`). The button is disabled immediately on click; if the click fires again before the stop path runs it is a no-op with a log message. The Start button is re-enabled in all error paths.
- **Visible error on mic denial** — if `requestMicStream()` or `startKeywordSpotter()` throws (permission denied, API unavailable, model load failure), the error message is written to `#log` and the Start button is restored; the UI is never left in a half-started state.
- **Type safety** — no `as any` anywhere. Narrowed typed read helpers (`readTimbre() → TimbreId`, `readKey() → Key`, `readDegree() → Degree`, `readRegister() → Register`) isolate the cast sites; the rest of the code is fully typed.

## Manual validation note

Full manual validation — actually hearing a round play, singing a degree, speaking a digit — has **not** been done in this subagent. That requires a real browser with mic access and speakers. A human should do that after merge (and Task 12's Playwright smoke test provides a baseline automated check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)