### PR TITLE
fix(speech): idempotent startKeywordSpotter + CPU backend fallback

### DIFF
--- a/src/speech/keyword-spotter.ts
+++ b/src/speech/keyword-spotter.ts
@@ -26,12 +26,68 @@ export interface StartKeywordSpotterInput {
 }
 
 /**
+ * Module-level idempotency state.
+ *
+ * At most one `recognizer.listen` stream is active at a time. Concurrent or
+ * repeated calls to `startKeywordSpotter` share the same handle:
+ *
+ *   - `activeHandle`  — set once listening is established; returned synchronously
+ *                       (via Promise.resolve) to any caller that arrives after
+ *                       the first call resolves.
+ *   - `activePromise` — in-flight Promise while the first call is loading the
+ *                       model and starting the stream; collapsed to callers that
+ *                       arrive concurrently before it resolves.
+ *
+ * State transitions:
+ *   IDLE              activeHandle=null, activePromise=null
+ *   LOADING           activeHandle=null, activePromise=<pending>
+ *   ACTIVE            activeHandle=<handle>, activePromise=<resolved>
+ *   IDLE (after stop) activeHandle=null, activePromise=null  (fresh start next call)
+ *
+ * NOTE: The `probabilityThreshold` and `minConfidence` parameters from `input`
+ * are applied on the FIRST call only. Subsequent callers that pass different
+ * values receive the existing handle unchanged — the thresholds they specify are
+ * silently ignored. Callers that need different thresholds must call stop() first
+ * and then start a new session.
+ */
+let activeHandle: KeywordSpotterHandle | null = null;
+let activePromise: Promise<KeywordSpotterHandle> | null = null;
+
+/**
  * Start listening for digit keywords. The speech-commands library internally opens
  * its own mic stream; no MediaStream needs to be passed in.
+ *
+ * This function is idempotent: multiple callers share a single `recognizer.listen`
+ * stream. Concurrent calls collapse to the same in-flight Promise; calls after
+ * the stream is established return `Promise.resolve(activeHandle)` immediately.
+ * All callers subscribe via the shared `Set<>`, so every subscriber receives
+ * every frame from the single live stream.
  */
 export async function startKeywordSpotter(
   input: StartKeywordSpotterInput = {},
 ): Promise<KeywordSpotterHandle> {
+  // Already active — return the existing handle immediately.
+  if (activeHandle !== null) {
+    return Promise.resolve(activeHandle);
+  }
+
+  // In-flight load — collapse concurrent callers to the same Promise.
+  if (activePromise !== null) {
+    return activePromise;
+  }
+
+  // First caller: build the Promise, store it, then await.
+  activePromise = _createHandle(input);
+
+  // On failure, null activePromise so the next call retries cleanly.
+  activePromise.catch(() => {
+    activePromise = null;
+  });
+
+  return activePromise;
+}
+
+async function _createHandle(input: StartKeywordSpotterInput): Promise<KeywordSpotterHandle> {
   const probabilityThreshold = input.probabilityThreshold ?? 0.75;
   const minConfidence = input.minConfidence ?? 0.75;
   const recognizer: Recognizer = await loadKwsRecognizer();
@@ -82,14 +138,23 @@ export async function startKeywordSpotter(
     },
   );
 
-  return {
+  const handle: KeywordSpotterHandle = {
     async stop() {
       subscribers.clear();
       await recognizer.stopListening();
+      // Null both module-level slots so subsequent startKeywordSpotter calls
+      // get a completely fresh listener.
+      activeHandle = null;
+      activePromise = null;
     },
     subscribe(cb) {
       subscribers.add(cb);
       return () => { subscribers.delete(cb); };
     },
   };
+
+  // Publish the handle at module scope so future callers get it immediately.
+  activeHandle = handle;
+
+  return handle;
 }

--- a/src/speech/keyword-spotter.ts
+++ b/src/speech/keyword-spotter.ts
@@ -140,12 +140,13 @@ async function _createHandle(input: StartKeywordSpotterInput): Promise<KeywordSp
 
   const handle: KeywordSpotterHandle = {
     async stop() {
-      subscribers.clear();
-      await recognizer.stopListening();
-      // Null both module-level slots so subsequent startKeywordSpotter calls
-      // get a completely fresh listener.
+      // Null the module-level cache FIRST so any concurrent startKeywordSpotter()
+      // call during the stopListening() await creates a fresh listener instead of
+      // returning this dying handle (which has an already-cleared subscribers Set).
       activeHandle = null;
       activePromise = null;
+      subscribers.clear();
+      await recognizer.stopListening();
     },
     subscribe(cb) {
       subscribers.add(cb);

--- a/src/speech/keyword-spotter.ts
+++ b/src/speech/keyword-spotter.ts
@@ -52,6 +52,7 @@ export interface StartKeywordSpotterInput {
  */
 let activeHandle: KeywordSpotterHandle | null = null;
 let activePromise: Promise<KeywordSpotterHandle> | null = null;
+let activeStop: Promise<void> | null = null;
 
 /**
  * Start listening for digit keywords. The speech-commands library internally opens
@@ -91,6 +92,9 @@ async function _createHandle(input: StartKeywordSpotterInput): Promise<KeywordSp
   const probabilityThreshold = input.probabilityThreshold ?? 0.75;
   const minConfidence = input.minConfidence ?? 0.75;
   const recognizer: Recognizer = await loadKwsRecognizer();
+  // Serialize after any in-flight stop so speech-commands doesn't throw
+  // "Cannot start streaming again when streaming is ongoing."
+  if (activeStop) await activeStop;
   const labels = recognizer.wordLabels();
 
   const digitIndexes: number[] = DIGIT_LABELS.map((d) => labels.indexOf(d));
@@ -146,7 +150,17 @@ async function _createHandle(input: StartKeywordSpotterInput): Promise<KeywordSp
       activeHandle = null;
       activePromise = null;
       subscribers.clear();
-      await recognizer.stopListening();
+      // Capture the in-flight stopListening so a concurrent start() can await
+      // it before calling recognizer.listen() — otherwise speech-commands throws
+      // "Cannot start streaming again when streaming is ongoing."
+      activeStop = (async () => {
+        try {
+          await recognizer.stopListening();
+        } finally {
+          activeStop = null;
+        }
+      })();
+      await activeStop;
     },
     subscribe(cb) {
       subscribers.add(cb);

--- a/src/speech/kws-loader.ts
+++ b/src/speech/kws-loader.ts
@@ -1,4 +1,5 @@
 import '@tensorflow/tfjs-backend-webgl';
+import '@tensorflow/tfjs-backend-cpu';
 import * as speechCommands from '@tensorflow-models/speech-commands';
 
 export type Recognizer = speechCommands.SpeechCommandRecognizer;


### PR DESCRIPTION
## Summary

- **Fix 1 — `startKeywordSpotter` idempotency:** adds module-level `activeHandle: KeywordSpotterHandle | null` and `activePromise: Promise<KeywordSpotterHandle> | null` so the function is safe to call from multiple callers (session state machine, replay controls, etc.) without each needing its own guard. Concurrent callers collapse to the same in-flight Promise; callers arriving after the stream is live get `Promise.resolve(activeHandle)` immediately. All callers subscribe via the shared `Set<>`, receiving every frame from the single live stream. `stop()` nulls both slots so a subsequent `startKeywordSpotter` call gets a completely fresh listener. Parameters (`probabilityThreshold`, `minConfidence`) from the first call win; callers needing different thresholds must stop + restart — documented in a comment.

- **Fix 2 — CPU backend fallback:** adds `import '@tensorflow/tfjs-backend-cpu'` in `src/speech/kws-loader.ts` immediately after the WebGL import. The package was already a direct dep (installed in PR #11) but was never imported, so the backend never registered itself. With both imports present, tfjs-core's priority-based backend selection prefers WebGL (priority 2) when available and falls back to CPU (priority 1) otherwise — covering headless Chromium, locked-down corporate environments, and future Playwright KWS e2e tests.

Both close deferred items from the PR #11 R8 mandatory-find review pass.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 124 passing (no regressions)
- [x] `npm run build` — succeeds (bundle unchanged at 0.76 kB; tfjs-backend-cpu is a CDN/runtime dep, not bundled)
- [x] `npm run test:e2e` — 1 passing
- [x] `grep -n tfjs-backend src/speech/kws-loader.ts` shows both `-webgl` and `-cpu` side-effect imports
- [x] `grep -n 'activeHandle\|activePromise' src/speech/keyword-spotter.ts` shows module-level declarations, idempotent entry check, and stop() nullification

🤖 Generated with [Claude Code](https://claude.com/claude-code)