### PR TITLE
fix(degree-mapping): export IN_KEY_CENTS constant

### DIFF
--- a/packages/core/src/pitch/degree-mapping.ts
+++ b/packages/core/src/pitch/degree-mapping.ts
@@ -10,8 +10,12 @@ export interface DegreeMapping {
   inKey: boolean;
 }
 
-/** Pitch must be within this cents range of a diatonic degree to count as "in key". */
-const IN_KEY_CENTS = 50;
+/**
+ * Pitch must be within ±50 cents of a diatonic degree to count as "in key."
+ * For equidistant pitches, the first degree in iteration order (ascending from 1)
+ * wins the tie-break deterministically.
+ */
+export const IN_KEY_CENTS = 50;
 
 /**
  * Map a detected Hz to the nearest diatonic scale degree in the given key,

--- a/packages/core/tests/pitch/degree-mapping.test.ts
+++ b/packages/core/tests/pitch/degree-mapping.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { mapHzToDegree } from '@/pitch/degree-mapping';
+import { mapHzToDegree, IN_KEY_CENTS } from '@/pitch/degree-mapping';
 import { C_MAJOR, A_MINOR } from '../helpers/fixtures';
 import { midiToHz, pitchClassToMidi } from '@/audio/note-math';
+
+describe('IN_KEY_CENTS', () => {
+  it('is exported and equals 50', () => {
+    expect(IN_KEY_CENTS).toBe(50);
+  });
+});
 
 describe('mapHzToDegree', () => {
   it('exact C maps to degree 1 in C major', () => {


### PR DESCRIPTION
## Summary
- Export the private IN_KEY_CENTS constant from degree-mapping.ts
- Add docstring about deterministic tie-break for equidistant pitches
- Add test verifying the export and value

## Test plan
- [ ] pnpm run test — all tests pass
- [ ] pnpm run typecheck — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)