### PR TITLE
feat(speech): add digitLabelToNumber conversion helper

### DIFF
--- a/packages/web-platform/src/speech/digit-label.ts
+++ b/packages/web-platform/src/speech/digit-label.ts
@@ -1,0 +1,7 @@
+import { DIGIT_LABELS, type DigitLabel } from './keyword-spotter';
+
+export function digitLabelToNumber(label: DigitLabel): number {
+  const idx = DIGIT_LABELS.indexOf(label);
+  if (idx < 0) throw new Error(`Unknown digit label: "${label}"`);
+  return idx + 1;
+}

--- a/packages/web-platform/src/speech/digit-label.ts
+++ b/packages/web-platform/src/speech/digit-label.ts
@@ -1,7 +1,8 @@
 import { DIGIT_LABELS, type DigitLabel } from './keyword-spotter';
+import type { Degree } from '@ear-training/core/types/music';
 
-export function digitLabelToNumber(label: DigitLabel): number {
+export function digitLabelToNumber(label: DigitLabel): Degree {
   const idx = DIGIT_LABELS.indexOf(label);
   if (idx < 0) throw new Error(`Unknown digit label: "${label}"`);
-  return idx + 1;
+  return (idx + 1) as Degree;
 }

--- a/packages/web-platform/tests/speech/digit-label.test.ts
+++ b/packages/web-platform/tests/speech/digit-label.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { digitLabelToNumber } from '@/speech/digit-label';
+import { DIGIT_LABELS, type DigitLabel } from '@/speech/keyword-spotter';
+
+describe('digitLabelToNumber', () => {
+  it.each([
+    ['one', 1],
+    ['two', 2],
+    ['three', 3],
+    ['four', 4],
+    ['five', 5],
+    ['six', 6],
+    ['seven', 7],
+  ] as const)('converts "%s" to %d', (label, expected) => {
+    expect(digitLabelToNumber(label)).toBe(expected);
+  });
+
+  it('throws on unknown label', () => {
+    expect(() => digitLabelToNumber('eight' as DigitLabel)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- New `digitLabelToNumber` function converts KWS DigitLabel strings to numbers 1-7
- Throws on unknown labels
- 8 test cases (7 conversions + 1 error case)

## Test plan
- [ ] pnpm run test — all tests pass
- [ ] pnpm run typecheck — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)