### PR TITLE
feat(ui-tokens): add design token constants (TS + CSS)

### DIFF
--- a/packages/ui-tokens/src/tokens.css
+++ b/packages/ui-tokens/src/tokens.css
@@ -1,0 +1,11 @@
+:root {
+  --bg: #0a0a0a;
+  --panel: #141414;
+  --border: #2a2a2a;
+  --text: #f5f5f7;
+  --muted: #86868b;
+  --cyan: #22d3ee;
+  --amber: #fbbf24;
+  --green: #22c55e;
+  --red: #ef4444;
+}

--- a/packages/ui-tokens/src/tokens.ts
+++ b/packages/ui-tokens/src/tokens.ts
@@ -1,1 +1,13 @@
-export {};
+export const colors = {
+  bg: '#0a0a0a',
+  panel: '#141414',
+  border: '#2a2a2a',
+  text: '#f5f5f7',
+  muted: '#86868b',
+  cyan: '#22d3ee',
+  amber: '#fbbf24',
+  green: '#22c55e',
+  red: '#ef4444',
+} as const;
+
+export type ColorToken = keyof typeof colors;

--- a/packages/ui-tokens/tests/tokens.test.ts
+++ b/packages/ui-tokens/tests/tokens.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { colors } from '@/tokens';
+
+describe('ui-tokens agreement', () => {
+  it('tokens.css declares every color from tokens.ts with matching value', () => {
+    const cssPath = fileURLToPath(new URL('../src/tokens.css', import.meta.url));
+    const css = readFileSync(cssPath, 'utf-8');
+
+    for (const [name, hex] of Object.entries(colors)) {
+      const escaped = hex.replace('#', '\\#');
+      const pattern = new RegExp(`--${name}:\\s*${escaped}\\s*;`);
+      expect(css, `Missing or wrong --${name}: ${hex}`).toMatch(pattern);
+    }
+  });
+
+  it('tokens.css has no extra custom properties not in tokens.ts', () => {
+    const cssPath = fileURLToPath(new URL('../src/tokens.css', import.meta.url));
+    const css = readFileSync(cssPath, 'utf-8');
+    const cssVars = [...css.matchAll(/--(\w+):/g)].map((m) => m[1]);
+    const tsKeys = Object.keys(colors);
+    for (const v of cssVars) {
+      expect(tsKeys, `Extra CSS var --${v} not in tokens.ts`).toContain(v);
+    }
+  });
+});

--- a/packages/ui-tokens/vitest.config.ts
+++ b/packages/ui-tokens/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['tests/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Design tokens as TypeScript constants (`colors` object) and CSS custom properties
- Unit test verifies every TS key has matching CSS custom property and vice versa
- Dark audio-app aesthetic per spec

## Test plan
- [ ] pnpm run test — all tests pass
- [ ] pnpm run typecheck — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)