### PR TITLE
feat(variability): add per-round timbre and register pickers

### DIFF
--- a/packages/core/src/variability/pickers.ts
+++ b/packages/core/src/variability/pickers.ts
@@ -1,0 +1,36 @@
+import type { Register } from '@/types/domain';
+
+export const TIMBRE_IDS = ['piano', 'epiano', 'guitar', 'pad'] as const;
+export type TimbreId = (typeof TIMBRE_IDS)[number];
+
+const REGISTERS: readonly Register[] = ['narrow', 'comfortable', 'wide'];
+
+export interface VariabilityHistory {
+  lastTimbre: TimbreId | null;
+  lastRegister: Register | null;
+}
+
+export interface VariabilitySettings {
+  lockedTimbre: TimbreId | null;
+  lockedRegister: Register | null;
+}
+
+export function pickTimbre(
+  rng: () => number,
+  history: VariabilityHistory,
+  settings: VariabilitySettings,
+): TimbreId {
+  if (settings.lockedTimbre !== null) return settings.lockedTimbre;
+  const pool = TIMBRE_IDS.filter((t) => t !== history.lastTimbre);
+  return pool[Math.floor(rng() * pool.length)]!;
+}
+
+export function pickRegister(
+  rng: () => number,
+  history: VariabilityHistory,
+  settings: VariabilitySettings,
+): Register {
+  if (settings.lockedRegister !== null) return settings.lockedRegister;
+  const pool = REGISTERS.filter((r) => r !== history.lastRegister);
+  return pool[Math.floor(rng() * pool.length)]!;
+}

--- a/packages/core/tests/variability/pickers.test.ts
+++ b/packages/core/tests/variability/pickers.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pickTimbre,
+  pickRegister,
+  TIMBRE_IDS,
+  type VariabilityHistory,
+  type VariabilitySettings,
+} from '@/variability/pickers';
+
+const NO_HISTORY: VariabilityHistory = { lastTimbre: null, lastRegister: null };
+const NO_LOCKS: VariabilitySettings = { lockedTimbre: null, lockedRegister: null };
+
+describe('pickTimbre', () => {
+  it('returns a valid TimbreId', () => {
+    const result = pickTimbre(() => 0.5, NO_HISTORY, NO_LOCKS);
+    expect(TIMBRE_IDS).toContain(result);
+  });
+
+  it('avoids repeating the last timbre', () => {
+    const results = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      results.add(pickTimbre(() => Math.random(), { ...NO_HISTORY, lastTimbre: 'piano' }, NO_LOCKS));
+    }
+    expect(results.has('piano')).toBe(false);
+  });
+
+  it('returns locked timbre regardless of history', () => {
+    const result = pickTimbre(
+      () => 0.5,
+      { ...NO_HISTORY, lastTimbre: 'guitar' },
+      { ...NO_LOCKS, lockedTimbre: 'guitar' },
+    );
+    expect(result).toBe('guitar');
+  });
+});
+
+describe('pickRegister', () => {
+  it('returns a valid Register', () => {
+    const result = pickRegister(() => 0.5, NO_HISTORY, NO_LOCKS);
+    expect(['narrow', 'comfortable', 'wide']).toContain(result);
+  });
+
+  it('avoids repeating the last register', () => {
+    const results = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      results.add(pickRegister(() => Math.random(), { ...NO_HISTORY, lastRegister: 'narrow' }, NO_LOCKS));
+    }
+    expect(results.has('narrow')).toBe(false);
+  });
+
+  it('returns locked register', () => {
+    const result = pickRegister(
+      () => 0.5,
+      NO_HISTORY,
+      { ...NO_LOCKS, lockedRegister: 'wide' },
+    );
+    expect(result).toBe('wide');
+  });
+});


### PR DESCRIPTION
## Summary
- `pickTimbre` and `pickRegister` with anti-repeat logic
- Settings override (locked timbre/register)
- `TIMBRE_IDS` and `TimbreId` defined in core (intentional duplication from web-platform)

## Test plan
- [ ] pnpm run test — all tests pass
- [ ] pnpm run typecheck — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)