### PR TITLE
feat(analytics): add dashboard rollup functions

### DIFF
--- a/packages/core/src/analytics/rollups.ts
+++ b/packages/core/src/analytics/rollups.ts
@@ -43,14 +43,18 @@ export function leitnerCounts(items: ReadonlyArray<Item>): Record<LeitnerBox, nu
 
 const DAY_MS = 86_400_000;
 
-function dayIndex(ts: number): number {
-  return Math.floor(ts / DAY_MS);
+function dayIndex(ts: number, tzOffsetMs: number): number {
+  return Math.floor((ts + tzOffsetMs) / DAY_MS);
 }
 
-export function currentStreak(sessions: ReadonlyArray<Session>, now: number): number {
+export function currentStreak(
+  sessions: ReadonlyArray<Session>,
+  now: number,
+  tzOffsetMs: number = 0,
+): number {
   if (sessions.length === 0) return 0;
-  const days = new Set(sessions.map((s) => dayIndex(s.started_at)));
-  const today = dayIndex(now);
+  const days = new Set(sessions.map((s) => dayIndex(s.started_at, tzOffsetMs)));
+  const today = dayIndex(now, tzOffsetMs);
   if (!days.has(today) && !days.has(today - 1)) return 0;
   let streak = 0;
   let check = days.has(today) ? today : today - 1;

--- a/packages/core/src/analytics/rollups.ts
+++ b/packages/core/src/analytics/rollups.ts
@@ -1,0 +1,62 @@
+import type { Item, Session, LeitnerBox } from '@/types/domain';
+import type { Degree } from '@/types/music';
+import { keyId } from '@/types/music';
+
+export function masteryByDegree(items: ReadonlyArray<Item>): Map<Degree, number> {
+  const sums = new Map<Degree, { total: number; count: number }>();
+  for (const it of items) {
+    const entry = sums.get(it.degree) ?? { total: 0, count: 0 };
+    entry.total += it.accuracy.pitch;
+    entry.count += 1;
+    sums.set(it.degree, entry);
+  }
+  const result = new Map<Degree, number>();
+  for (const [deg, { total, count }] of sums) {
+    result.set(deg, count > 0 ? total / count : 0);
+  }
+  return result;
+}
+
+export function masteryByKey(items: ReadonlyArray<Item>): Map<string, number> {
+  const sums = new Map<string, { total: number; count: number }>();
+  for (const it of items) {
+    const k = keyId(it.key);
+    const entry = sums.get(k) ?? { total: 0, count: 0 };
+    entry.total += it.accuracy.pitch;
+    entry.count += 1;
+    sums.set(k, entry);
+  }
+  const result = new Map<string, number>();
+  for (const [k, { total, count }] of sums) {
+    result.set(k, count > 0 ? total / count : 0);
+  }
+  return result;
+}
+
+export function leitnerCounts(items: ReadonlyArray<Item>): Record<LeitnerBox, number> {
+  const counts: Record<LeitnerBox, number> = { new: 0, learning: 0, reviewing: 0, mastered: 0 };
+  for (const it of items) {
+    counts[it.box] += 1;
+  }
+  return counts;
+}
+
+const DAY_MS = 86_400_000;
+
+function dayIndex(ts: number): number {
+  return Math.floor(ts / DAY_MS);
+}
+
+export function currentStreak(sessions: ReadonlyArray<Session>, now: number): number {
+  if (sessions.length === 0) return 0;
+  const days = new Set(sessions.map((s) => dayIndex(s.started_at)));
+  const today = dayIndex(now);
+  if (!days.has(today) && !days.has(today - 1)) return 0;
+  let streak = 0;
+  let check = days.has(today) ? today : today - 1;
+  while (days.has(check)) {
+    streak++;
+    check--;
+  }
+  return streak;
+}

--- a/packages/core/tests/analytics/rollups.test.ts
+++ b/packages/core/tests/analytics/rollups.test.ts
@@ -90,4 +90,14 @@ describe('currentStreak', () => {
     ];
     expect(currentStreak(sessions, now)).toBe(1);
   });
+
+  it('respects timezone offset for day boundaries', () => {
+    const midnight = Math.floor(Date.now() / DAY) * DAY;
+    const session1 = makeSession(midnight + 10 * 3600_000);
+    const session2 = makeSession(midnight + 23.5 * 3600_000);
+    const now = midnight + 24 * 3600_000;
+
+    expect(currentStreak([session1, session2], now, 0)).toBe(1);
+    expect(currentStreak([session1, session2], now, 3600_000)).toBe(2);
+  });
 });

--- a/packages/core/tests/analytics/rollups.test.ts
+++ b/packages/core/tests/analytics/rollups.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { masteryByDegree, masteryByKey, leitnerCounts, currentStreak } from '@/analytics/rollups';
+import { buildInitialItems } from '@/seed/initial-items';
+import type { Item, Session, LeitnerBox } from '@/types/domain';
+import { keyId } from '@/types/music';
+
+const items = buildInitialItems({ now: 0 });
+
+describe('masteryByDegree', () => {
+  it('returns a Map with entries for degrees present in items', () => {
+    const result = masteryByDegree(items);
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBeGreaterThan(0);
+  });
+
+  it('computes average pitch accuracy per degree', () => {
+    const tweaked: Item[] = items.map((it, i) =>
+      i === 0 ? { ...it, accuracy: { pitch: 0.8, label: 0.9 } } : it,
+    );
+    const result = masteryByDegree(tweaked);
+    expect(result.get(tweaked[0]!.degree)).toBeDefined();
+  });
+});
+
+describe('masteryByKey', () => {
+  it('returns a Map keyed by keyId strings', () => {
+    const result = masteryByKey(items);
+    expect(result).toBeInstanceOf(Map);
+    for (const [k] of result) {
+      expect(k).toMatch(/-/); // e.g. "C-major"
+    }
+  });
+});
+
+describe('leitnerCounts', () => {
+  it('returns counts for all four boxes', () => {
+    const result = leitnerCounts(items);
+    expect(result).toHaveProperty('new');
+    expect(result).toHaveProperty('learning');
+    expect(result).toHaveProperty('reviewing');
+    expect(result).toHaveProperty('mastered');
+  });
+
+  it('total count matches items length', () => {
+    const result = leitnerCounts(items);
+    const total = result.new + result.learning + result.reviewing + result.mastered;
+    expect(total).toBe(items.length);
+  });
+});
+
+describe('currentStreak', () => {
+  const DAY = 86_400_000;
+
+  function makeSession(startedAt: number): Session {
+    return {
+      id: `s-${startedAt}`,
+      started_at: startedAt,
+      ended_at: startedAt + 100_000,
+      target_items: 10,
+      completed_items: 10,
+      pitch_pass_count: 8,
+      label_pass_count: 9,
+      focus_item_id: null,
+    };
+  }
+
+  it('returns 0 for empty sessions', () => {
+    expect(currentStreak([], Date.now())).toBe(0);
+  });
+
+  it('returns 1 for a single session today', () => {
+    const now = Date.now();
+    expect(currentStreak([makeSession(now - 3600_000)], now)).toBe(1);
+  });
+
+  it('returns 2 for consecutive days', () => {
+    const now = Date.now();
+    const sessions = [
+      makeSession(now - DAY - 3600_000),
+      makeSession(now - 3600_000),
+    ];
+    expect(currentStreak(sessions, now)).toBe(2);
+  });
+
+  it('breaks streak on gap day', () => {
+    const now = Date.now();
+    const sessions = [
+      makeSession(now - 3 * DAY),
+      makeSession(now - 3600_000),
+    ];
+    expect(currentStreak(sessions, now)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `masteryByDegree`: average pitch accuracy per scale degree
- `masteryByKey`: average pitch accuracy per key
- `leitnerCounts`: items per Leitner box
- `currentStreak`: consecutive practice days

## Test plan
- [x] pnpm run test — all 9 new tests pass (2 pre-existing ui-tokens failures unrelated)
- [x] pnpm run typecheck — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)