### PR TITLE
feat(round): add pure pitch grading helper

### DIFF
--- a/packages/core/src/round/events.ts
+++ b/packages/core/src/round/events.ts
@@ -1,0 +1,11 @@
+import type { Item, Register } from '@/types/domain';
+import type { TimbreId } from '@/variability/pickers';
+
+export type RoundEvent =
+  | { type: 'ROUND_STARTED';   at_ms: number; item: Item; timbre: TimbreId; register: Register }
+  | { type: 'CADENCE_STARTED'; at_ms: number }
+  | { type: 'TARGET_STARTED';  at_ms: number }
+  | { type: 'PITCH_FRAME';     at_ms: number; hz: number; confidence: number }
+  | { type: 'DIGIT_HEARD';     at_ms: number; digit: number; confidence: number }
+  | { type: 'PLAYBACK_DONE';   at_ms: number }
+  | { type: 'USER_CANCELED';   at_ms: number };

--- a/packages/core/src/round/grade-pitch.ts
+++ b/packages/core/src/round/grade-pitch.ts
@@ -1,7 +1,5 @@
 import type { Item } from '@/types/domain';
 import { mapHzToDegree } from '@/pitch/degree-mapping';
-import { centsBetween, pitchClassToMidi, midiToHz } from '@/audio/note-math';
-import { semitoneOffset } from '@/types/music';
 
 export interface PitchObservation {
   at_ms: number;
@@ -29,10 +27,7 @@ export function gradePitch(
 
   const mapping = mapHzToDegree(best.hz, item.key);
   const pitchOk = mapping !== null && mapping.degree === item.degree && mapping.inKey;
-
-  const targetMidi = pitchClassToMidi(item.key.tonic, 4) + semitoneOffset(item.degree, item.key.quality);
-  const targetHz = midiToHz(targetMidi);
-  const cents_off = centsBetween(best.hz, targetHz);
+  const cents_off = mapping !== null ? mapping.cents : null;
 
   return { pitchOk, sungBest: best, cents_off };
 }

--- a/packages/core/src/round/grade-pitch.ts
+++ b/packages/core/src/round/grade-pitch.ts
@@ -1,0 +1,38 @@
+import type { Item } from '@/types/domain';
+import { mapHzToDegree } from '@/pitch/degree-mapping';
+import { centsBetween, pitchClassToMidi, midiToHz } from '@/audio/note-math';
+import { semitoneOffset } from '@/types/music';
+
+export interface PitchObservation {
+  at_ms: number;
+  hz: number;
+  confidence: number;
+}
+
+export interface PitchGrade {
+  pitchOk: boolean;
+  sungBest: PitchObservation | null;
+  cents_off: number | null;
+}
+
+export function gradePitch(
+  frames: ReadonlyArray<PitchObservation>,
+  item: Item,
+  minConfidence: number,
+): PitchGrade {
+  const confident = frames.filter((f) => f.confidence >= minConfidence && f.hz > 0);
+  if (confident.length === 0) {
+    return { pitchOk: false, sungBest: null, cents_off: null };
+  }
+
+  const best = confident.reduce((a, b) => (b.confidence > a.confidence ? b : a));
+
+  const mapping = mapHzToDegree(best.hz, item.key);
+  const pitchOk = mapping !== null && mapping.degree === item.degree && mapping.inKey;
+
+  const targetMidi = pitchClassToMidi(item.key.tonic, 4) + semitoneOffset(item.degree, item.key.quality);
+  const targetHz = midiToHz(targetMidi);
+  const cents_off = centsBetween(best.hz, targetHz);
+
+  return { pitchOk, sungBest: best, cents_off };
+}

--- a/packages/core/tests/round/events.test.ts
+++ b/packages/core/tests/round/events.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import type { RoundEvent } from '@/round/events';
+import type { Item } from '@/types/domain';
+
+describe('RoundEvent', () => {
+  it('ROUND_STARTED carries item, timbre, register', () => {
+    const ev: RoundEvent = {
+      type: 'ROUND_STARTED',
+      at_ms: 100,
+      item: { id: 'test' } as Item,
+      timbre: 'piano',
+      register: 'narrow',
+    };
+    expect(ev.type).toBe('ROUND_STARTED');
+  });
+
+  it('PITCH_FRAME carries hz and confidence', () => {
+    const ev: RoundEvent = { type: 'PITCH_FRAME', at_ms: 200, hz: 440, confidence: 0.92 };
+    expect(ev.hz).toBe(440);
+  });
+
+  it('DIGIT_HEARD carries digit and confidence', () => {
+    const ev: RoundEvent = { type: 'DIGIT_HEARD', at_ms: 300, digit: 5, confidence: 0.88 };
+    expect(ev.digit).toBe(5);
+  });
+
+  it('all seven event types are constructable', () => {
+    const events: RoundEvent[] = [
+      { type: 'ROUND_STARTED', at_ms: 0, item: {} as Item, timbre: 'piano', register: 'narrow' },
+      { type: 'CADENCE_STARTED', at_ms: 10 },
+      { type: 'TARGET_STARTED', at_ms: 20 },
+      { type: 'PITCH_FRAME', at_ms: 30, hz: 440, confidence: 0.9 },
+      { type: 'DIGIT_HEARD', at_ms: 40, digit: 3, confidence: 0.8 },
+      { type: 'PLAYBACK_DONE', at_ms: 50 },
+      { type: 'USER_CANCELED', at_ms: 60 },
+    ];
+    expect(events).toHaveLength(7);
+  });
+});

--- a/packages/core/tests/round/grade-pitch.test.ts
+++ b/packages/core/tests/round/grade-pitch.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { gradePitch, type PitchObservation } from '@/round/grade-pitch';
+import type { Item } from '@/types/domain';
+
+const C_MAJOR_ITEM: Item = {
+  id: '1-C-major', degree: 1,
+  key: { tonic: 'C', quality: 'major' },
+  box: 'new', accuracy: { pitch: 0, label: 0 },
+  recent: [], attempts: 0, consecutive_passes: 0,
+  last_seen_at: null, due_at: 0, created_at: 0,
+};
+
+function makeItem(degree: 1|2|3|4|5|6|7): Item {
+  return { ...C_MAJOR_ITEM, id: `${degree}-C-major`, degree };
+}
+
+describe('gradePitch', () => {
+  it('returns pitchOk=true when best frame matches target degree', () => {
+    const frames: PitchObservation[] = [
+      { at_ms: 100, hz: 261.63, confidence: 0.95 }, // C4 = degree 1 in C major
+    ];
+    const result = gradePitch(frames, makeItem(1), 0.5);
+    expect(result.pitchOk).toBe(true);
+    expect(result.sungBest).not.toBeNull();
+  });
+
+  it('returns pitchOk=false when best frame is a different degree', () => {
+    const frames: PitchObservation[] = [
+      { at_ms: 100, hz: 329.63, confidence: 0.95 }, // E4 = degree 3
+    ];
+    const result = gradePitch(frames, makeItem(1), 0.5);
+    expect(result.pitchOk).toBe(false);
+  });
+
+  it('ignores frames below minConfidence', () => {
+    const frames: PitchObservation[] = [
+      { at_ms: 100, hz: 261.63, confidence: 0.2 },  // correct but low confidence
+      { at_ms: 200, hz: 329.63, confidence: 0.95 },  // wrong but high confidence
+    ];
+    const result = gradePitch(frames, makeItem(1), 0.5);
+    expect(result.pitchOk).toBe(false);
+    expect(result.sungBest?.hz).toBeCloseTo(329.63);
+  });
+
+  it('picks highest-confidence frame as sungBest', () => {
+    const frames: PitchObservation[] = [
+      { at_ms: 100, hz: 261.63, confidence: 0.7 },
+      { at_ms: 200, hz: 261.63, confidence: 0.95 },
+      { at_ms: 300, hz: 261.63, confidence: 0.8 },
+    ];
+    const result = gradePitch(frames, makeItem(1), 0.5);
+    expect(result.sungBest?.confidence).toBe(0.95);
+  });
+
+  it('returns null sungBest when no frames meet minConfidence', () => {
+    const frames: PitchObservation[] = [
+      { at_ms: 100, hz: 261.63, confidence: 0.1 },
+    ];
+    const result = gradePitch(frames, makeItem(1), 0.5);
+    expect(result.sungBest).toBeNull();
+    expect(result.pitchOk).toBe(false);
+    expect(result.cents_off).toBeNull();
+  });
+
+  it('returns null sungBest for empty frames', () => {
+    const result = gradePitch([], makeItem(1), 0.5);
+    expect(result.sungBest).toBeNull();
+    expect(result.pitchOk).toBe(false);
+  });
+
+  it('reports cents_off for the best frame', () => {
+    const frames: PitchObservation[] = [
+      { at_ms: 100, hz: 265, confidence: 0.95 }, // slightly sharp C4
+    ];
+    const result = gradePitch(frames, makeItem(1), 0.5);
+    expect(result.cents_off).not.toBeNull();
+    expect(Math.abs(result.cents_off!)).toBeGreaterThan(0);
+    expect(Math.abs(result.cents_off!)).toBeLessThan(100);
+  });
+
+  it('works octave-invariant (C5 matches degree 1 in C major)', () => {
+    const frames: PitchObservation[] = [
+      { at_ms: 100, hz: 523.25, confidence: 0.95 }, // C5
+    ];
+    const result = gradePitch(frames, makeItem(1), 0.5);
+    expect(result.pitchOk).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `gradePitch(frames, item, minConfidence)` → `{ pitchOk, sungBest, cents_off }`
- Picks highest-confidence frame above threshold
- Octave-invariant via existing `mapHzToDegree`
- 8 test cases covering match, mismatch, confidence filtering, empty frames

## Test plan
- [ ] pnpm run test — all tests pass
- [ ] pnpm run typecheck — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)