### PR TITLE
feat(round-adapters): wall-clock event adapters

### DIFF
--- a/packages/core/src/round/state.ts
+++ b/packages/core/src/round/state.ts
@@ -1,0 +1,79 @@
+import type { Item, Register, AttemptOutcome } from '@/types/domain';
+import type { TimbreId } from '@/variability/pickers';
+import type { RoundEvent } from './events';
+import type { PitchObservation } from './grade-pitch';
+
+export type RoundState =
+  | { kind: 'idle' }
+  | { kind: 'playing_cadence'; item: Item; timbre: TimbreId; register: Register; startedAt: number }
+  | { kind: 'playing_target';  item: Item; timbre: TimbreId; register: Register; targetStartedAt: number; frames: PitchObservation[] }
+  | { kind: 'listening';       item: Item; timbre: TimbreId; register: Register; targetStartedAt: number; frames: PitchObservation[]; digit: number | null; digitConfidence: number }
+  | { kind: 'graded';          item: Item; timbre: TimbreId; register: Register; outcome: AttemptOutcome; sungBest: PitchObservation | null; digitHeard: number | null };
+
+export function roundReducer(state: RoundState, event: RoundEvent): RoundState {
+  if (event.type === 'USER_CANCELED' && state.kind !== 'idle' && state.kind !== 'graded') {
+    return { kind: 'idle' };
+  }
+
+  switch (state.kind) {
+    case 'idle':
+      if (event.type === 'ROUND_STARTED') {
+        return {
+          kind: 'playing_cadence',
+          item: event.item,
+          timbre: event.timbre,
+          register: event.register,
+          startedAt: event.at_ms,
+        };
+      }
+      return state;
+
+    case 'playing_cadence':
+      if (event.type === 'TARGET_STARTED') {
+        return {
+          kind: 'playing_target',
+          item: state.item, timbre: state.timbre, register: state.register,
+          targetStartedAt: event.at_ms,
+          frames: [],
+        };
+      }
+      return state;
+
+    case 'playing_target':
+      if (event.type === 'PITCH_FRAME') {
+        return {
+          ...state,
+          frames: [...state.frames, { at_ms: event.at_ms, hz: event.hz, confidence: event.confidence }],
+        };
+      }
+      if (event.type === 'PLAYBACK_DONE') {
+        return {
+          kind: 'listening',
+          item: state.item, timbre: state.timbre, register: state.register,
+          targetStartedAt: state.targetStartedAt,
+          frames: state.frames,
+          digit: null,
+          digitConfidence: 0,
+        };
+      }
+      return state;
+
+    case 'listening':
+      if (event.type === 'PITCH_FRAME') {
+        return {
+          ...state,
+          frames: [...state.frames, { at_ms: event.at_ms, hz: event.hz, confidence: event.confidence }],
+        };
+      }
+      if (event.type === 'DIGIT_HEARD') {
+        if (event.confidence > state.digitConfidence) {
+          return { ...state, digit: event.digit, digitConfidence: event.confidence };
+        }
+        return state;
+      }
+      return state;
+
+    case 'graded':
+      return state;
+  }
+}

--- a/packages/core/tests/round/state.test.ts
+++ b/packages/core/tests/round/state.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { roundReducer, type RoundState } from '@/round/state';
+import type { RoundEvent } from '@/round/events';
+import type { Item } from '@/types/domain';
+
+const ITEM: Item = {
+  id: '1-C-major', degree: 1,
+  key: { tonic: 'C', quality: 'major' },
+  box: 'new', accuracy: { pitch: 0, label: 0 },
+  recent: [], attempts: 0, consecutive_passes: 0,
+  last_seen_at: null, due_at: 0, created_at: 0,
+};
+
+const idle: RoundState = { kind: 'idle' };
+
+describe('roundReducer', () => {
+  // === Valid transitions ===
+
+  describe('idle → playing_cadence', () => {
+    it('transitions on ROUND_STARTED', () => {
+      const ev: RoundEvent = { type: 'ROUND_STARTED', at_ms: 100, item: ITEM, timbre: 'piano', register: 'narrow' };
+      const next = roundReducer(idle, ev);
+      expect(next.kind).toBe('playing_cadence');
+      if (next.kind === 'playing_cadence') {
+        expect(next.item).toBe(ITEM);
+        expect(next.timbre).toBe('piano');
+        expect(next.startedAt).toBe(100);
+      }
+    });
+  });
+
+  describe('playing_cadence → playing_target', () => {
+    it('transitions on TARGET_STARTED', () => {
+      const cadence: RoundState = { kind: 'playing_cadence', item: ITEM, timbre: 'piano', register: 'narrow', startedAt: 100 };
+      const next = roundReducer(cadence, { type: 'TARGET_STARTED', at_ms: 200 });
+      expect(next.kind).toBe('playing_target');
+      if (next.kind === 'playing_target') {
+        expect(next.targetStartedAt).toBe(200);
+        expect(next.frames).toEqual([]);
+      }
+    });
+  });
+
+  describe('playing_target', () => {
+    const target: RoundState = {
+      kind: 'playing_target', item: ITEM, timbre: 'piano', register: 'narrow',
+      targetStartedAt: 200, frames: [],
+    };
+
+    it('accumulates PITCH_FRAME', () => {
+      const next = roundReducer(target, { type: 'PITCH_FRAME', at_ms: 250, hz: 440, confidence: 0.9 });
+      expect(next.kind).toBe('playing_target');
+      if (next.kind === 'playing_target') {
+        expect(next.frames).toHaveLength(1);
+        expect(next.frames[0]!.hz).toBe(440);
+      }
+    });
+
+    it('transitions to listening on PLAYBACK_DONE', () => {
+      const next = roundReducer(target, { type: 'PLAYBACK_DONE', at_ms: 350 });
+      expect(next.kind).toBe('listening');
+    });
+  });
+
+  describe('listening', () => {
+    const listening: RoundState = {
+      kind: 'listening', item: ITEM, timbre: 'piano', register: 'narrow',
+      targetStartedAt: 200, frames: [{ at_ms: 250, hz: 261.63, confidence: 0.95 }],
+      digit: null, digitConfidence: 0,
+    };
+
+    it('accumulates PITCH_FRAME', () => {
+      const next = roundReducer(listening, { type: 'PITCH_FRAME', at_ms: 400, hz: 262, confidence: 0.9 });
+      expect(next.kind).toBe('listening');
+      if (next.kind === 'listening') expect(next.frames).toHaveLength(2);
+    });
+
+    it('records DIGIT_HEARD', () => {
+      const next = roundReducer(listening, { type: 'DIGIT_HEARD', at_ms: 500, digit: 1, confidence: 0.88 });
+      if (next.kind === 'listening') {
+        expect(next.digit).toBe(1);
+        expect(next.digitConfidence).toBe(0.88);
+      }
+    });
+
+    it('keeps highest-confidence digit', () => {
+      let state = roundReducer(listening, { type: 'DIGIT_HEARD', at_ms: 500, digit: 1, confidence: 0.9 });
+      state = roundReducer(state, { type: 'DIGIT_HEARD', at_ms: 600, digit: 3, confidence: 0.7 });
+      if (state.kind === 'listening') {
+        expect(state.digit).toBe(1);
+        expect(state.digitConfidence).toBe(0.9);
+      }
+    });
+  });
+
+  // === Cancel ===
+  describe('USER_CANCELED', () => {
+    it('returns idle from playing_cadence', () => {
+      const state: RoundState = { kind: 'playing_cadence', item: ITEM, timbre: 'piano', register: 'narrow', startedAt: 100 };
+      expect(roundReducer(state, { type: 'USER_CANCELED', at_ms: 150 }).kind).toBe('idle');
+    });
+
+    it('returns idle from playing_target', () => {
+      const state: RoundState = { kind: 'playing_target', item: ITEM, timbre: 'piano', register: 'narrow', targetStartedAt: 200, frames: [] };
+      expect(roundReducer(state, { type: 'USER_CANCELED', at_ms: 250 }).kind).toBe('idle');
+    });
+
+    it('returns idle from listening', () => {
+      const state: RoundState = { kind: 'listening', item: ITEM, timbre: 'piano', register: 'narrow', targetStartedAt: 200, frames: [], digit: null, digitConfidence: 0 };
+      expect(roundReducer(state, { type: 'USER_CANCELED', at_ms: 350 }).kind).toBe('idle');
+    });
+  });
+
+  // === Ignored events (return state unchanged) ===
+  describe('ignored events', () => {
+    it('ignores CADENCE_STARTED in idle', () => {
+      expect(roundReducer(idle, { type: 'CADENCE_STARTED', at_ms: 100 })).toBe(idle);
+    });
+    it('ignores TARGET_STARTED in idle', () => {
+      expect(roundReducer(idle, { type: 'TARGET_STARTED', at_ms: 100 })).toBe(idle);
+    });
+    it('ignores PITCH_FRAME in idle', () => {
+      expect(roundReducer(idle, { type: 'PITCH_FRAME', at_ms: 100, hz: 440, confidence: 0.9 })).toBe(idle);
+    });
+    it('ignores DIGIT_HEARD in idle', () => {
+      expect(roundReducer(idle, { type: 'DIGIT_HEARD', at_ms: 100, digit: 1, confidence: 0.9 })).toBe(idle);
+    });
+    it('ignores PLAYBACK_DONE in idle', () => {
+      expect(roundReducer(idle, { type: 'PLAYBACK_DONE', at_ms: 100 })).toBe(idle);
+    });
+    it('ignores ROUND_STARTED in playing_cadence', () => {
+      const state: RoundState = { kind: 'playing_cadence', item: ITEM, timbre: 'piano', register: 'narrow', startedAt: 100 };
+      expect(roundReducer(state, { type: 'ROUND_STARTED', at_ms: 200, item: ITEM, timbre: 'guitar', register: 'wide' })).toBe(state);
+    });
+    it('ignores all events in graded', () => {
+      const graded: RoundState = {
+        kind: 'graded', item: ITEM, timbre: 'piano', register: 'narrow',
+        outcome: { pitch: true, label: true, pass: true, at: 500 },
+        sungBest: null, digitHeard: null,
+      };
+      expect(roundReducer(graded, { type: 'ROUND_STARTED', at_ms: 600, item: ITEM, timbre: 'guitar', register: 'wide' })).toBe(graded);
+      expect(roundReducer(graded, { type: 'USER_CANCELED', at_ms: 600 })).toBe(graded);
+    });
+  });
+});

--- a/packages/web-platform/src/round-adapters/clock.ts
+++ b/packages/web-platform/src/round-adapters/clock.ts
@@ -1,0 +1,5 @@
+export interface Clock {
+  now(): number;
+}
+
+export const systemClock: Clock = { now: () => Date.now() };

--- a/packages/web-platform/src/round-adapters/index.ts
+++ b/packages/web-platform/src/round-adapters/index.ts
@@ -1,0 +1,41 @@
+import type { RoundEvent } from '@ear-training/core/round/events';
+import type { Item, Register } from '@ear-training/core/types/domain';
+import type { TimbreId } from '@ear-training/core/variability/pickers';
+import type { PitchFrame } from '@/pitch/pitch-detector';
+import type { DigitFrame } from '@/speech/keyword-spotter';
+import { digitLabelToNumber } from '@/speech/digit-label';
+import { systemClock, type Clock } from './clock';
+
+export function pitchFrameToEvent(frame: PitchFrame, clock: Clock = systemClock): RoundEvent {
+  return { type: 'PITCH_FRAME', at_ms: clock.now(), hz: frame.hz, confidence: frame.confidence };
+}
+
+export function digitFrameToEvent(frame: DigitFrame, clock: Clock = systemClock): RoundEvent | null {
+  if (frame.digit === null) return null;
+  return {
+    type: 'DIGIT_HEARD',
+    at_ms: clock.now(),
+    digit: digitLabelToNumber(frame.digit),
+    confidence: frame.confidence,
+  };
+}
+
+export function targetStartedEvent(clock: Clock = systemClock): RoundEvent {
+  return { type: 'TARGET_STARTED', at_ms: clock.now() };
+}
+
+export function cadenceStartedEvent(clock: Clock = systemClock): RoundEvent {
+  return { type: 'CADENCE_STARTED', at_ms: clock.now() };
+}
+
+export function playbackDoneEvent(clock: Clock = systemClock): RoundEvent {
+  return { type: 'PLAYBACK_DONE', at_ms: clock.now() };
+}
+
+export function roundStartedEvent(item: Item, timbre: TimbreId, register: Register, clock: Clock = systemClock): RoundEvent {
+  return { type: 'ROUND_STARTED', at_ms: clock.now(), item, timbre, register };
+}
+
+export function userCanceledEvent(clock: Clock = systemClock): RoundEvent {
+  return { type: 'USER_CANCELED', at_ms: clock.now() };
+}

--- a/packages/web-platform/tests/round-adapters/adapters.test.ts
+++ b/packages/web-platform/tests/round-adapters/adapters.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pitchFrameToEvent,
+  digitFrameToEvent,
+  targetStartedEvent,
+  cadenceStartedEvent,
+  playbackDoneEvent,
+  roundStartedEvent,
+  userCanceledEvent,
+} from '@/round-adapters/index';
+import type { Clock } from '@/round-adapters/clock';
+import type { PitchFrame } from '@/pitch/pitch-detector';
+import type { DigitFrame } from '@/speech/keyword-spotter';
+import type { Item } from '@ear-training/core/types/domain';
+
+const stubClock: Clock = { now: () => 42_000 };
+
+const ITEM: Item = {
+  id: '1-C-major', degree: 1,
+  key: { tonic: 'C', quality: 'major' },
+  box: 'new', accuracy: { pitch: 0, label: 0 },
+  recent: [], attempts: 0, consecutive_passes: 0,
+  last_seen_at: null, due_at: 0, created_at: 0,
+};
+
+describe('pitchFrameToEvent', () => {
+  it('converts PitchFrame to PITCH_FRAME event with wall-clock at_ms', () => {
+    const frame: PitchFrame = { hz: 440, confidence: 0.92, at: 1.5 };
+    const ev = pitchFrameToEvent(frame, stubClock);
+    expect(ev.type).toBe('PITCH_FRAME');
+    expect(ev.at_ms).toBe(42_000);
+    if (ev.type === 'PITCH_FRAME') {
+      expect(ev.hz).toBe(440);
+      expect(ev.confidence).toBe(0.92);
+    }
+  });
+});
+
+describe('digitFrameToEvent', () => {
+  it('converts DigitFrame with a digit to DIGIT_HEARD event', () => {
+    const frame: DigitFrame = {
+      digit: 'three',
+      confidence: 0.88,
+      scores: { one: 0.1, two: 0.1, three: 0.88, four: 0.05, five: 0.02, six: 0.01, seven: 0.01 },
+    };
+    const ev = digitFrameToEvent(frame, stubClock);
+    expect(ev).not.toBeNull();
+    if (ev && ev.type === 'DIGIT_HEARD') {
+      expect(ev.digit).toBe(3);
+      expect(ev.confidence).toBe(0.88);
+      expect(ev.at_ms).toBe(42_000);
+    }
+  });
+
+  it('returns null for DigitFrame with null digit', () => {
+    const frame: DigitFrame = {
+      digit: null,
+      confidence: 0.3,
+      scores: { one: 0.1, two: 0.1, three: 0.1, four: 0.1, five: 0.1, six: 0.1, seven: 0.1 },
+    };
+    expect(digitFrameToEvent(frame, stubClock)).toBeNull();
+  });
+});
+
+describe('simple event factories', () => {
+  it('targetStartedEvent', () => {
+    expect(targetStartedEvent(stubClock)).toEqual({ type: 'TARGET_STARTED', at_ms: 42_000 });
+  });
+  it('cadenceStartedEvent', () => {
+    expect(cadenceStartedEvent(stubClock)).toEqual({ type: 'CADENCE_STARTED', at_ms: 42_000 });
+  });
+  it('playbackDoneEvent', () => {
+    expect(playbackDoneEvent(stubClock)).toEqual({ type: 'PLAYBACK_DONE', at_ms: 42_000 });
+  });
+  it('userCanceledEvent', () => {
+    expect(userCanceledEvent(stubClock)).toEqual({ type: 'USER_CANCELED', at_ms: 42_000 });
+  });
+  it('roundStartedEvent', () => {
+    const ev = roundStartedEvent(ITEM, 'piano', 'narrow', stubClock);
+    expect(ev.type).toBe('ROUND_STARTED');
+    expect(ev.at_ms).toBe(42_000);
+    if (ev.type === 'ROUND_STARTED') {
+      expect(ev.item).toBe(ITEM);
+      expect(ev.timbre).toBe('piano');
+      expect(ev.register).toBe('narrow');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- 7 adapter functions converting audio-stack signals to RoundEvent values
- Injectable `Clock` interface for deterministic tests
- `digitFrameToEvent` uses `digitLabelToNumber` for label→number conversion
- Returns `null` for DigitFrame with no recognized digit

## Test plan
- [x] pnpm run test — 215 tests pass (8 new)
- [x] pnpm run typecheck — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)