### PR TITLE
test(round): integration tests for round reducer

### DIFF
--- a/packages/core/tests/round/round-integration.test.ts
+++ b/packages/core/tests/round/round-integration.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { roundReducer, type RoundState } from '@/round/state';
+import type { RoundEvent } from '@/round/events';
+import type { Item } from '@/types/domain';
+
+const ITEM: Item = {
+  id: '1-C-major', degree: 1,
+  key: { tonic: 'C', quality: 'major' },
+  box: 'new', accuracy: { pitch: 0, label: 0 },
+  recent: [], attempts: 0, consecutive_passes: 0,
+  last_seen_at: null, due_at: 0, created_at: 0,
+};
+
+function applyEvents(events: RoundEvent[]): RoundState {
+  return events.reduce<RoundState>((s, e) => roundReducer(s, e), { kind: 'idle' });
+}
+
+describe('round integration: golden path', () => {
+  it('progresses from idle through all states to listening', () => {
+    const events: RoundEvent[] = [
+      { type: 'ROUND_STARTED', at_ms: 0, item: ITEM, timbre: 'piano', register: 'narrow' },
+      { type: 'CADENCE_STARTED', at_ms: 10 },
+      { type: 'TARGET_STARTED', at_ms: 3200 },
+      { type: 'PITCH_FRAME', at_ms: 3300, hz: 261.63, confidence: 0.95 },
+      { type: 'PITCH_FRAME', at_ms: 3400, hz: 262.0, confidence: 0.93 },
+      { type: 'PLAYBACK_DONE', at_ms: 4700 },
+      { type: 'PITCH_FRAME', at_ms: 4800, hz: 261.5, confidence: 0.91 },
+      { type: 'DIGIT_HEARD', at_ms: 5000, digit: 1, confidence: 0.88 },
+    ];
+
+    const final = applyEvents(events);
+    expect(final.kind).toBe('listening');
+    if (final.kind === 'listening') {
+      expect(final.frames).toHaveLength(3);
+      expect(final.digit).toBe(1);
+      expect(final.digitConfidence).toBe(0.88);
+      expect(final.item).toBe(ITEM);
+    }
+  });
+});
+
+describe('round integration: cancel mid-round', () => {
+  it('returns to idle when canceled during playing_target', () => {
+    const events: RoundEvent[] = [
+      { type: 'ROUND_STARTED', at_ms: 0, item: ITEM, timbre: 'guitar', register: 'comfortable' },
+      { type: 'TARGET_STARTED', at_ms: 3200 },
+      { type: 'PITCH_FRAME', at_ms: 3300, hz: 440, confidence: 0.9 },
+      { type: 'USER_CANCELED', at_ms: 3500 },
+    ];
+    expect(applyEvents(events).kind).toBe('idle');
+  });
+
+  it('returns to idle when canceled during listening', () => {
+    const events: RoundEvent[] = [
+      { type: 'ROUND_STARTED', at_ms: 0, item: ITEM, timbre: 'pad', register: 'wide' },
+      { type: 'TARGET_STARTED', at_ms: 3200 },
+      { type: 'PLAYBACK_DONE', at_ms: 4700 },
+      { type: 'USER_CANCELED', at_ms: 5000 },
+    ];
+    expect(applyEvents(events).kind).toBe('idle');
+  });
+});
+
+describe('round integration: timeout with no pitch', () => {
+  it('reaches listening with empty frames when no pitch is detected', () => {
+    const events: RoundEvent[] = [
+      { type: 'ROUND_STARTED', at_ms: 0, item: ITEM, timbre: 'epiano', register: 'narrow' },
+      { type: 'TARGET_STARTED', at_ms: 3200 },
+      { type: 'PLAYBACK_DONE', at_ms: 4700 },
+    ];
+    const final = applyEvents(events);
+    expect(final.kind).toBe('listening');
+    if (final.kind === 'listening') {
+      expect(final.frames).toHaveLength(0);
+      expect(final.digit).toBeNull();
+    }
+  });
+});
+
+describe('round integration: wrong digit', () => {
+  it('records the wrong digit in listening state', () => {
+    const events: RoundEvent[] = [
+      { type: 'ROUND_STARTED', at_ms: 0, item: ITEM, timbre: 'piano', register: 'narrow' },
+      { type: 'TARGET_STARTED', at_ms: 3200 },
+      { type: 'PITCH_FRAME', at_ms: 3300, hz: 261.63, confidence: 0.95 },
+      { type: 'PLAYBACK_DONE', at_ms: 4700 },
+      { type: 'DIGIT_HEARD', at_ms: 5000, digit: 5, confidence: 0.8 },
+    ];
+    const final = applyEvents(events);
+    if (final.kind === 'listening') {
+      expect(final.digit).toBe(5);
+    }
+  });
+});
+
+describe('round integration: multiple digit attempts', () => {
+  it('keeps highest confidence digit across multiple DIGIT_HEARD events', () => {
+    const events: RoundEvent[] = [
+      { type: 'ROUND_STARTED', at_ms: 0, item: ITEM, timbre: 'piano', register: 'narrow' },
+      { type: 'TARGET_STARTED', at_ms: 3200 },
+      { type: 'PLAYBACK_DONE', at_ms: 4700 },
+      { type: 'DIGIT_HEARD', at_ms: 5000, digit: 3, confidence: 0.6 },
+      { type: 'DIGIT_HEARD', at_ms: 5500, digit: 1, confidence: 0.92 },
+      { type: 'DIGIT_HEARD', at_ms: 6000, digit: 5, confidence: 0.7 },
+    ];
+    const final = applyEvents(events);
+    if (final.kind === 'listening') {
+      expect(final.digit).toBe(1);
+      expect(final.digitConfidence).toBe(0.92);
+    }
+  });
+});

--- a/packages/web-platform/src/round-adapters/clock.ts
+++ b/packages/web-platform/src/round-adapters/clock.ts
@@ -1,0 +1,5 @@
+export interface Clock {
+  now(): number;
+}
+
+export const systemClock: Clock = { now: () => Date.now() };

--- a/packages/web-platform/src/round-adapters/index.ts
+++ b/packages/web-platform/src/round-adapters/index.ts
@@ -1,0 +1,41 @@
+import type { RoundEvent } from '@ear-training/core/round/events';
+import type { Item, Register } from '@ear-training/core/types/domain';
+import type { TimbreId } from '@ear-training/core/variability/pickers';
+import type { PitchFrame } from '@/pitch/pitch-detector';
+import type { DigitFrame } from '@/speech/keyword-spotter';
+import { digitLabelToNumber } from '@/speech/digit-label';
+import { systemClock, type Clock } from './clock';
+
+export function pitchFrameToEvent(frame: PitchFrame, clock: Clock = systemClock): RoundEvent {
+  return { type: 'PITCH_FRAME', at_ms: clock.now(), hz: frame.hz, confidence: frame.confidence };
+}
+
+export function digitFrameToEvent(frame: DigitFrame, clock: Clock = systemClock): RoundEvent | null {
+  if (frame.digit === null) return null;
+  return {
+    type: 'DIGIT_HEARD',
+    at_ms: clock.now(),
+    digit: digitLabelToNumber(frame.digit),
+    confidence: frame.confidence,
+  };
+}
+
+export function targetStartedEvent(clock: Clock = systemClock): RoundEvent {
+  return { type: 'TARGET_STARTED', at_ms: clock.now() };
+}
+
+export function cadenceStartedEvent(clock: Clock = systemClock): RoundEvent {
+  return { type: 'CADENCE_STARTED', at_ms: clock.now() };
+}
+
+export function playbackDoneEvent(clock: Clock = systemClock): RoundEvent {
+  return { type: 'PLAYBACK_DONE', at_ms: clock.now() };
+}
+
+export function roundStartedEvent(item: Item, timbre: TimbreId, register: Register, clock: Clock = systemClock): RoundEvent {
+  return { type: 'ROUND_STARTED', at_ms: clock.now(), item, timbre, register };
+}
+
+export function userCanceledEvent(clock: Clock = systemClock): RoundEvent {
+  return { type: 'USER_CANCELED', at_ms: clock.now() };
+}

--- a/packages/web-platform/tests/round-adapters/adapters.test.ts
+++ b/packages/web-platform/tests/round-adapters/adapters.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pitchFrameToEvent,
+  digitFrameToEvent,
+  targetStartedEvent,
+  cadenceStartedEvent,
+  playbackDoneEvent,
+  roundStartedEvent,
+  userCanceledEvent,
+} from '@/round-adapters/index';
+import type { Clock } from '@/round-adapters/clock';
+import type { PitchFrame } from '@/pitch/pitch-detector';
+import type { DigitFrame } from '@/speech/keyword-spotter';
+import type { Item } from '@ear-training/core/types/domain';
+
+const stubClock: Clock = { now: () => 42_000 };
+
+const ITEM: Item = {
+  id: '1-C-major', degree: 1,
+  key: { tonic: 'C', quality: 'major' },
+  box: 'new', accuracy: { pitch: 0, label: 0 },
+  recent: [], attempts: 0, consecutive_passes: 0,
+  last_seen_at: null, due_at: 0, created_at: 0,
+};
+
+describe('pitchFrameToEvent', () => {
+  it('converts PitchFrame to PITCH_FRAME event with wall-clock at_ms', () => {
+    const frame: PitchFrame = { hz: 440, confidence: 0.92, at: 1.5 };
+    const ev = pitchFrameToEvent(frame, stubClock);
+    expect(ev.type).toBe('PITCH_FRAME');
+    expect(ev.at_ms).toBe(42_000);
+    if (ev.type === 'PITCH_FRAME') {
+      expect(ev.hz).toBe(440);
+      expect(ev.confidence).toBe(0.92);
+    }
+  });
+});
+
+describe('digitFrameToEvent', () => {
+  it('converts DigitFrame with a digit to DIGIT_HEARD event', () => {
+    const frame: DigitFrame = {
+      digit: 'three',
+      confidence: 0.88,
+      scores: { one: 0.1, two: 0.1, three: 0.88, four: 0.05, five: 0.02, six: 0.01, seven: 0.01 },
+    };
+    const ev = digitFrameToEvent(frame, stubClock);
+    expect(ev).not.toBeNull();
+    if (ev && ev.type === 'DIGIT_HEARD') {
+      expect(ev.digit).toBe(3);
+      expect(ev.confidence).toBe(0.88);
+      expect(ev.at_ms).toBe(42_000);
+    }
+  });
+
+  it('returns null for DigitFrame with null digit', () => {
+    const frame: DigitFrame = {
+      digit: null,
+      confidence: 0.3,
+      scores: { one: 0.1, two: 0.1, three: 0.1, four: 0.1, five: 0.1, six: 0.1, seven: 0.1 },
+    };
+    expect(digitFrameToEvent(frame, stubClock)).toBeNull();
+  });
+});
+
+describe('simple event factories', () => {
+  it('targetStartedEvent', () => {
+    expect(targetStartedEvent(stubClock)).toEqual({ type: 'TARGET_STARTED', at_ms: 42_000 });
+  });
+  it('cadenceStartedEvent', () => {
+    expect(cadenceStartedEvent(stubClock)).toEqual({ type: 'CADENCE_STARTED', at_ms: 42_000 });
+  });
+  it('playbackDoneEvent', () => {
+    expect(playbackDoneEvent(stubClock)).toEqual({ type: 'PLAYBACK_DONE', at_ms: 42_000 });
+  });
+  it('userCanceledEvent', () => {
+    expect(userCanceledEvent(stubClock)).toEqual({ type: 'USER_CANCELED', at_ms: 42_000 });
+  });
+  it('roundStartedEvent', () => {
+    const ev = roundStartedEvent(ITEM, 'piano', 'narrow', stubClock);
+    expect(ev.type).toBe('ROUND_STARTED');
+    expect(ev.at_ms).toBe(42_000);
+    if (ev.type === 'ROUND_STARTED') {
+      expect(ev.item).toBe(ITEM);
+      expect(ev.timbre).toBe('piano');
+      expect(ev.register).toBe('narrow');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Golden path: idle → cadence → target → listening with frames + digit
- Cancel: returns idle from playing_target and listening
- Timeout: empty frames when no pitch detected
- Wrong digit: records incorrect digit
- Multiple digits: keeps highest confidence

## Test plan
- [ ] pnpm run test — all tests pass
- [ ] pnpm run typecheck — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)