### PR TITLE
fix: pre-C1 foundation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage/
 .env
 .env.local
 .superpowers/
+.worktrees/
 
 # playwright MCP session artifacts — contains downloaded files, screenshots,
 # accessibility snapshots, and console logs. May include secrets pulled from

--- a/packages/core/src/round/events.ts
+++ b/packages/core/src/round/events.ts
@@ -1,4 +1,5 @@
 import type { Item, Register } from '@/types/domain';
+import type { Degree } from '@/types/music';
 import type { TimbreId } from '@/variability/pickers';
 
 export type RoundEvent =
@@ -6,6 +7,6 @@ export type RoundEvent =
   | { type: 'CADENCE_STARTED'; at_ms: number }
   | { type: 'TARGET_STARTED';  at_ms: number }
   | { type: 'PITCH_FRAME';     at_ms: number; hz: number; confidence: number }
-  | { type: 'DIGIT_HEARD';     at_ms: number; digit: number; confidence: number }
+  | { type: 'DIGIT_HEARD';     at_ms: number; digit: Degree; confidence: number }
   | { type: 'PLAYBACK_DONE';   at_ms: number }
   | { type: 'USER_CANCELED';   at_ms: number };

--- a/packages/core/src/round/state.ts
+++ b/packages/core/src/round/state.ts
@@ -1,4 +1,5 @@
 import type { Item, Register, AttemptOutcome } from '@/types/domain';
+import type { Degree } from '@/types/music';
 import type { TimbreId } from '@/variability/pickers';
 import type { RoundEvent } from './events';
 import type { PitchObservation } from './grade-pitch';
@@ -7,8 +8,8 @@ export type RoundState =
   | { kind: 'idle' }
   | { kind: 'playing_cadence'; item: Item; timbre: TimbreId; register: Register; startedAt: number }
   | { kind: 'playing_target';  item: Item; timbre: TimbreId; register: Register; targetStartedAt: number; frames: PitchObservation[] }
-  | { kind: 'listening';       item: Item; timbre: TimbreId; register: Register; targetStartedAt: number; frames: PitchObservation[]; digit: number | null; digitConfidence: number }
-  | { kind: 'graded';          item: Item; timbre: TimbreId; register: Register; outcome: AttemptOutcome; sungBest: PitchObservation | null; digitHeard: number | null };
+  | { kind: 'listening';       item: Item; timbre: TimbreId; register: Register; targetStartedAt: number; frames: PitchObservation[]; digit: Degree | null; digitConfidence: number }
+  | { kind: 'graded';          item: Item; timbre: TimbreId; register: Register; outcome: AttemptOutcome; sungBest: PitchObservation | null; digitHeard: Degree | null };
 
 export function roundReducer(state: RoundState, event: RoundEvent): RoundState {
   if (event.type === 'USER_CANCELED' && state.kind !== 'idle' && state.kind !== 'graded') {

--- a/packages/core/src/session/orchestrator.ts
+++ b/packages/core/src/session/orchestrator.ts
@@ -1,4 +1,5 @@
 import type { Attempt, AttemptOutcome, Item, LeitnerBox, Register, Session } from '@/types/domain';
+import type { Degree } from '@/types/music';
 import type { ItemsRepo, AttemptsRepo, SessionsRepo } from '@/repos/interfaces';
 import { selectNextItem } from '@/scheduler/selection';
 import type { RoundHistoryEntry } from '@/scheduler/interleaving';
@@ -22,7 +23,7 @@ export interface RecordAttemptInput {
   item: Item;
   target: { hz: number };
   sung: { hz: number | null; cents_off: number | null; confidence: number };
-  spoken: { digit: number | null; confidence: number };
+  spoken: { digit: Degree | null; confidence: number };
   pitchOk: boolean;
   labelOk: boolean;
   timbre: string;

--- a/packages/core/src/types/domain.ts
+++ b/packages/core/src/types/domain.ts
@@ -53,7 +53,7 @@ export interface Attempt {
     confidence: number;
   };
   spoken: {
-    digit: number | null;
+    digit: Degree | null;
     confidence: number;
   };
   graded: AttemptOutcome;

--- a/packages/web-platform/src/speech/keyword-spotter.ts
+++ b/packages/web-platform/src/speech/keyword-spotter.ts
@@ -115,6 +115,7 @@ export async function startKeywordSpotter(
   // On failure, null activePromise so the next call retries cleanly.
   activePromise.catch(() => {
     activePromise = null;
+    activeThresholds = null;
   });
 
   return activePromise;

--- a/packages/web-platform/src/store/settings-repo.ts
+++ b/packages/web-platform/src/store/settings-repo.ts
@@ -11,7 +11,7 @@ export function createSettingsRepo(db: DB): _SettingsRepo {
   return {
     async getOrDefault() {
       const existing = await db.get('settings', KEY);
-      return existing ?? { ...DEFAULT_SETTINGS };
+      return { ...DEFAULT_SETTINGS, ...existing };
     },
 
     async update(partial: Partial<Settings>) {


### PR DESCRIPTION
## Summary

- **KWS activeThresholds stale on failure** — `activeThresholds` was not cleared when `_createHandle` rejected, allowing a retry with different thresholds to bypass safety guards. One-line fix.
- **Degree type leak** — `DIGIT_HEARD.digit` was typed `number` instead of `Degree`, widening through the reducer into `RoundState` and `Attempt`. Now correctly `Degree` across the full event → state → domain → orchestrator chain.
- **Settings-repo merge logic** — `getOrDefault()` returned stored settings without merging defaults, so new fields added to `Settings` wouldn't get defaults for existing users. Changed to `{ ...DEFAULT_SETTINGS, ...existing }`.
- Adds `.worktrees/` to `.gitignore` for future worktree-based development.

## Test plan

- [x] `pnpm run typecheck` — all 4 packages pass
- [x] `pnpm run test` — 221 tests pass, 0 failures
- [ ] `pnpm run test:e2e` — Playwright smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)