### PR TITLE
ci: add core CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Unit tests
+        run: pnpm run test
+
+      - name: Build
+        run: pnpm run build

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ear-training-monorepo",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "pnpm --filter ear-training-station dev",
     "build": "pnpm --filter ear-training-station build",


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` — runs typecheck, unit tests, and build on push to main and PRs
- Adds `packageManager` field to root `package.json` for pnpm version pinning in CI
- Concurrency control cancels stale runs on the same branch

## Test plan
- [ ] CI workflow runs on this PR and passes
- [ ] typecheck, test, and build steps all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)