### PR TITLE
ci: add sharded Playwright e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,47 @@
+# .github/workflows/e2e.yml
+name: E2E
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, ready_for_review]
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Run e2e tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+        run: pnpm --filter ear-training-station test:e2e -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report-shard-${{ matrix.shardIndex }}
+          path: apps/ear-training-station/test-results/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,8 @@ jobs:
         run: pnpm --filter ear-training-station exec playwright install chromium --with-deps
 
       - name: Run e2e tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
-        run: pnpm --filter ear-training-station test:e2e -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        working-directory: apps/ear-training-station
+        run: pnpm exec playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium --with-deps
+        run: pnpm --filter ear-training-station exec playwright install chromium --with-deps
 
       - name: Run e2e tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         run: pnpm --filter ear-training-station test:e2e -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/e2e.yml` — 4-shard Playwright matrix on PRs to main
- Skips draft PRs, uploads test artifacts on failure
- Prepares for e2e test suite growth in Plan C1

## Test plan
- [ ] E2E workflow runs on this PR (4 shards, 1 test distributed across them)
- [ ] All shards pass (empty shards exit cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)