### PR TITLE
ci: add bundle size reporting workflow

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Build and capture output
         run: pnpm run build 2>&1 | tee build-output.txt
+        env:
+          NO_COLOR: '1'
 
       - name: Report bundle size
         run: |

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,42 @@
+# .github/workflows/bundle-size.yml
+name: Bundle Size
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: bundle-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bundle-size:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build and capture output
+        run: pnpm run build 2>&1 | tee build-output.txt
+
+      - name: Report bundle size
+        run: |
+          echo "## Bundle Size Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| File | Size | Gzip |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|------|------|" >> $GITHUB_STEP_SUMMARY
+          grep -E "^\s*dist/" build-output.txt | while IFS= read -r line; do
+            file=$(echo "$line" | awk '{print $1}')
+            size=$(echo "$line" | awk '{print $2, $3}')
+            gzip=$(echo "$line" | awk -F'gzip: ' '{print $2}')
+            echo "| \`$file\` | $size | $gzip |" >> $GITHUB_STEP_SUMMARY
+          done


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/bundle-size.yml` — builds the app and reports chunk sizes in PR summary
- Parses Vite's build output into a markdown table (file, size, gzip)
- No external dependencies — pure shell parsing

## Test plan
- [ ] Bundle size workflow runs on this PR
- [ ] Check the Actions run summary for the bundle size table

🤖 Generated with [Claude Code](https://claude.com/claude-code)