### PR TITLE
fix(ci): remove draft PR skip from e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,6 @@ concurrency:
 
 jobs:
   e2e:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
## Summary
- Removes `if: github.event.pull_request.draft == false` from e2e workflow
- Mergify creates draft PRs for merge queue checks — the skip condition deadlocked the queue since branch protection requires all 4 e2e shards to pass

## Test plan
- [ ] E2E shards run on this PR (not skipped)
- [ ] Mergify queue unblocks after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)