### PR TITLE
feat(core): add onboarded flag to Settings

### DIFF
--- a/packages/core/src/types/domain.ts
+++ b/packages/core/src/types/domain.ts
@@ -78,6 +78,7 @@ export interface Settings {
   auto_advance_on_hit: boolean;
   session_length: 20 | 30 | 45;
   reduced_motion: 'auto' | 'on' | 'off';
+  onboarded: boolean;
 }
 
 export const DEFAULT_SETTINGS: Readonly<Settings> = Object.freeze({
@@ -85,4 +86,5 @@ export const DEFAULT_SETTINGS: Readonly<Settings> = Object.freeze({
   auto_advance_on_hit: true,
   session_length: 30,
   reduced_motion: 'auto',
+  onboarded: false,
 });

--- a/packages/web-platform/tests/store/settings-repo.onboarded.test.ts
+++ b/packages/web-platform/tests/store/settings-repo.onboarded.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { createSettingsRepo } from '@/store/settings-repo';
+import { openTestDB } from '../helpers/test-db';
+
+describe('SettingsRepo — onboarded flag', () => {
+  it('returns onboarded: false by default when no row exists', async () => {
+    const db = await openTestDB();
+    const repo = createSettingsRepo(db);
+    const settings = await repo.getOrDefault();
+    expect(settings.onboarded).toBe(false);
+  });
+
+  it('merges onboarded default into pre-existing rows that lack the field', async () => {
+    const db = await openTestDB();
+    // Simulate a row written before the field existed.
+    await db.put('settings', {
+      function_tooltip: true,
+      auto_advance_on_hit: true,
+      session_length: 30,
+      reduced_motion: 'auto',
+    } as never, 'singleton');
+
+    const repo = createSettingsRepo(db);
+    const settings = await repo.getOrDefault();
+    expect(settings.onboarded).toBe(false);
+    // existing fields preserved
+    expect(settings.session_length).toBe(30);
+  });
+
+  it('round-trips onboarded: true through update()', async () => {
+    const db = await openTestDB();
+    const repo = createSettingsRepo(db);
+    await repo.update({ onboarded: true });
+    const settings = await repo.getOrDefault();
+    expect(settings.onboarded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds onboarded: boolean to Settings with default false. Pre-existing IndexedDB rows get the default via the SettingsRepo schema-merge (PR #30).

## Test plan
- [x] pnpm --filter @ear-training/web-platform test settings-repo.onboarded — 3 new tests pass
- [x] pnpm run typecheck && pnpm run test — all existing tests pass

Part of Plan C1.1. See docs/specs/2026-04-16-plan-c1-ui-integration-design.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)