### PR TITLE
feat(core): CAPTURE_COMPLETE event and gradeListeningState

### DIFF
--- a/packages/core/src/round/events.ts
+++ b/packages/core/src/round/events.ts
@@ -1,12 +1,14 @@
 import type { Item, Register } from '@/types/domain';
 import type { Degree } from '@/types/music';
 import type { TimbreId } from '@/variability/pickers';
+import type { ListeningGrade } from './grade-listening';
 
 export type RoundEvent =
-  | { type: 'ROUND_STARTED';   at_ms: number; item: Item; timbre: TimbreId; register: Register }
-  | { type: 'CADENCE_STARTED'; at_ms: number }
-  | { type: 'TARGET_STARTED';  at_ms: number }
-  | { type: 'PITCH_FRAME';     at_ms: number; hz: number; confidence: number }
-  | { type: 'DIGIT_HEARD';     at_ms: number; digit: Degree; confidence: number }
-  | { type: 'PLAYBACK_DONE';   at_ms: number }
-  | { type: 'USER_CANCELED';   at_ms: number };
+  | { type: 'ROUND_STARTED';     at_ms: number; item: Item; timbre: TimbreId; register: Register }
+  | { type: 'CADENCE_STARTED';   at_ms: number }
+  | { type: 'TARGET_STARTED';    at_ms: number }
+  | { type: 'PITCH_FRAME';       at_ms: number; hz: number; confidence: number }
+  | { type: 'DIGIT_HEARD';       at_ms: number; digit: Degree; confidence: number }
+  | { type: 'PLAYBACK_DONE';     at_ms: number }
+  | { type: 'USER_CANCELED';     at_ms: number }
+  | { type: 'CAPTURE_COMPLETE'; at_ms: number; grade: ListeningGrade };

--- a/packages/core/src/round/grade-listening.ts
+++ b/packages/core/src/round/grade-listening.ts
@@ -1,0 +1,48 @@
+import type { Item, AttemptOutcome } from '@/types/domain';
+import type { Degree } from '@/types/music';
+import type { RoundState } from './state';
+import { gradePitch, type PitchObservation } from './grade-pitch';
+
+export interface GradingThresholds {
+  minPitchConfidence: number;
+  minDigitConfidence: number;
+}
+
+export interface ListeningGrade {
+  outcome: AttemptOutcome;
+  cents_off: number | null;
+  sungBest: PitchObservation | null;
+  spokenDigit: Degree | null;
+  spokenConfidence: number;
+}
+
+/**
+ * Compute the full graded bundle for a listening-state snapshot.
+ * Pure: same inputs → same output. Called by the session controller
+ * when capture-end conditions fire (timeout, auto-hit, user "next").
+ */
+export function gradeListeningState(
+  state: Extract<RoundState, { kind: 'listening' }>,
+  item: Item,
+  thresholds: GradingThresholds,
+): ListeningGrade {
+  const pitchGrade = gradePitch(state.frames, item, thresholds.minPitchConfidence);
+
+  const spokenDigit = state.digitConfidence >= thresholds.minDigitConfidence ? state.digit : null;
+  const labelOk = spokenDigit != null && spokenDigit === item.degree;
+
+  const outcome: AttemptOutcome = {
+    pitch: pitchGrade.pitchOk,
+    label: labelOk,
+    pass: pitchGrade.pitchOk && labelOk,
+    at: Date.now(), // placeholder; reducer stamps at_ms on dispatch
+  };
+
+  return {
+    outcome,
+    cents_off: pitchGrade.cents_off,
+    sungBest: pitchGrade.sungBest,
+    spokenDigit,
+    spokenConfidence: state.digitConfidence,
+  };
+}

--- a/packages/core/tests/round/events.test.ts
+++ b/packages/core/tests/round/events.test.ts
@@ -37,3 +37,20 @@ describe('RoundEvent', () => {
     expect(events).toHaveLength(7);
   });
 });
+
+describe('RoundEvent union — CAPTURE_COMPLETE', () => {
+  it('accepts a CAPTURE_COMPLETE event with a ListeningGrade payload', () => {
+    const event: RoundEvent = {
+      type: 'CAPTURE_COMPLETE',
+      at_ms: 1000,
+      grade: {
+        outcome: { pitch: true, label: true, pass: true, at: 1000 },
+        cents_off: 5,
+        sungBest: { at_ms: 500, hz: 440, confidence: 0.9 },
+        spokenDigit: 5,
+        spokenConfidence: 0.95,
+      },
+    };
+    expect(event.type).toBe('CAPTURE_COMPLETE');
+  });
+});

--- a/packages/core/tests/round/grade-listening.test.ts
+++ b/packages/core/tests/round/grade-listening.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { gradeListeningState } from '@/round/grade-listening';
+import type { RoundState } from '@/round/state';
+import type { Item } from '@/types/domain';
+
+const item: Item = {
+  id: '5-C-major',
+  degree: 5,
+  key: { tonic: 'C', quality: 'major' },
+  box: 'new',
+  accuracy: { pitch: 0, label: 0 },
+  recent: [],
+  attempts: 0,
+  consecutive_passes: 0,
+  last_seen_at: null,
+  due_at: 0,
+  created_at: 0,
+};
+
+function listeningState(partial: Partial<Extract<RoundState, { kind: 'listening' }>>): Extract<RoundState, { kind: 'listening' }> {
+  return {
+    kind: 'listening',
+    item,
+    timbre: 'piano',
+    register: 'comfortable',
+    targetStartedAt: 0,
+    frames: [],
+    digit: null,
+    digitConfidence: 0,
+    ...partial,
+  };
+}
+
+describe('gradeListeningState', () => {
+  it('returns pass when pitch is on-target and the digit matches the degree', () => {
+    const state = listeningState({
+      frames: [
+        { at_ms: 100, hz: 392, confidence: 0.95 },
+        { at_ms: 150, hz: 392, confidence: 0.95 },
+      ],
+      digit: 5,
+      digitConfidence: 0.9,
+    });
+    const grade = gradeListeningState(state, item, { minPitchConfidence: 0.5, minDigitConfidence: 0.5 });
+    expect(grade.outcome.pitch).toBe(true);
+    expect(grade.outcome.label).toBe(true);
+    expect(grade.outcome.pass).toBe(true);
+    expect(grade.cents_off).not.toBeNull();
+    expect(Math.abs(grade.cents_off!)).toBeLessThan(10);
+    expect(grade.sungBest).not.toBeNull();
+    expect(grade.spokenDigit).toBe(5);
+    expect(grade.spokenConfidence).toBe(0.9);
+  });
+
+  it('returns label: false when the spoken digit does not match', () => {
+    const state = listeningState({
+      frames: [{ at_ms: 100, hz: 392, confidence: 0.95 }],
+      digit: 4,
+      digitConfidence: 0.9,
+    });
+    const grade = gradeListeningState(state, item, { minPitchConfidence: 0.5, minDigitConfidence: 0.5 });
+    expect(grade.outcome.pitch).toBe(true);
+    expect(grade.outcome.label).toBe(false);
+    expect(grade.outcome.pass).toBe(false);
+    expect(grade.spokenDigit).toBe(4);
+  });
+
+  it('returns pitch: false when no confident frames exist', () => {
+    const state = listeningState({
+      frames: [{ at_ms: 100, hz: 392, confidence: 0.2 }],
+      digit: 5,
+      digitConfidence: 0.9,
+    });
+    const grade = gradeListeningState(state, item, { minPitchConfidence: 0.5, minDigitConfidence: 0.5 });
+    expect(grade.outcome.pitch).toBe(false);
+    expect(grade.cents_off).toBeNull();
+    expect(grade.sungBest).toBeNull();
+  });
+
+  it('returns label: false when digit confidence is below threshold', () => {
+    const state = listeningState({
+      frames: [{ at_ms: 100, hz: 392, confidence: 0.95 }],
+      digit: 5,
+      digitConfidence: 0.3,
+    });
+    const grade = gradeListeningState(state, item, { minPitchConfidence: 0.5, minDigitConfidence: 0.5 });
+    expect(grade.outcome.label).toBe(false);
+  });
+
+  it('returns label: false when no digit heard at all', () => {
+    const state = listeningState({
+      frames: [{ at_ms: 100, hz: 392, confidence: 0.95 }],
+      digit: null,
+      digitConfidence: 0,
+    });
+    const grade = gradeListeningState(state, item, { minPitchConfidence: 0.5, minDigitConfidence: 0.5 });
+    expect(grade.outcome.label).toBe(false);
+    expect(grade.spokenDigit).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Adds the \`CAPTURE_COMPLETE\` event variant (per Option B from the design spec) and the pure \`gradeListeningState()\` function that produces its payload.

## Test plan
- [x] \`pnpm --filter @ear-training/core test grade-listening\` — 5 new tests pass
- [x] \`pnpm --filter @ear-training/core test events\` — new CAPTURE_COMPLETE shape test passes
- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm run test\` — full suite green

Note: the reducer transition (\`listening + CAPTURE_COMPLETE → graded\`) lands in Task 4 on a separate PR.

Part of Plan C1.1. See \`docs/specs/2026-04-16-plan-c1-ui-integration-design.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)