### PR TITLE
feat(core): register-expansion gating

### DIFF
--- a/packages/core/src/scheduler/register-gating.ts
+++ b/packages/core/src/scheduler/register-gating.ts
@@ -1,0 +1,20 @@
+import type { Item, Register } from '@/types/domain';
+
+const ADVANCED: ReadonlyArray<Item['box']> = ['reviewing', 'mastered'];
+
+/** Minimum advanced-item counts at which each additional register unlocks. */
+const UNLOCK_THRESHOLDS: ReadonlyArray<{ register: Register; minAdvanced: number }> = [
+  { register: 'comfortable', minAdvanced: 0 },
+  { register: 'narrow',      minAdvanced: 3 },
+  { register: 'wide',        minAdvanced: 6 },
+];
+
+/**
+ * The set of registers the scheduler may pick from, given current item
+ * progression. Always includes 'comfortable'. 'narrow' and 'wide' unlock
+ * as the learner demonstrates mastery in more items.
+ */
+export function availableRegisters(items: ReadonlyArray<Item>): ReadonlyArray<Register> {
+  const advanced = items.filter((i) => ADVANCED.includes(i.box)).length;
+  return UNLOCK_THRESHOLDS.filter((t) => advanced >= t.minAdvanced).map((t) => t.register);
+}

--- a/packages/core/src/variability/pickers.ts
+++ b/packages/core/src/variability/pickers.ts
@@ -29,8 +29,13 @@ export function pickRegister(
   rng: () => number,
   history: VariabilityHistory,
   settings: VariabilitySettings,
+  available: ReadonlyArray<Register> = REGISTERS,
 ): Register {
-  if (settings.lockedRegister !== null) return settings.lockedRegister;
-  const pool = REGISTERS.filter((r) => r !== history.lastRegister);
-  return pool[Math.floor(rng() * pool.length)]!;
+  if (settings.lockedRegister != null && available.includes(settings.lockedRegister)) {
+    return settings.lockedRegister;
+  }
+  // Filter: avoid repeating the last register; fall back to available if that empties the pool
+  const pool = available.filter((r) => r !== history.lastRegister);
+  const chooseFrom = pool.length > 0 ? pool : available;
+  return chooseFrom[Math.floor(rng() * chooseFrom.length)]!;
 }

--- a/packages/core/tests/scheduler/register-gating.test.ts
+++ b/packages/core/tests/scheduler/register-gating.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { availableRegisters } from '@/scheduler/register-gating';
+import type { Item } from '@/types/domain';
+
+function itemInBox(id: string, box: Item['box']): Item {
+  return {
+    id, degree: 5, key: { tonic: 'C', quality: 'major' },
+    box, accuracy: { pitch: 0, label: 0 },
+    recent: [], attempts: 0, consecutive_passes: 0,
+    last_seen_at: null, due_at: 0, created_at: 0,
+  };
+}
+
+describe('availableRegisters', () => {
+  it('returns only "comfortable" when no items have advanced', () => {
+    const items = [itemInBox('a', 'new'), itemInBox('b', 'learning')];
+    expect(availableRegisters(items)).toEqual(['comfortable']);
+  });
+
+  it('unlocks "narrow" once ≥ 3 items are in reviewing or mastered', () => {
+    const items = [
+      itemInBox('a', 'reviewing'),
+      itemInBox('b', 'reviewing'),
+      itemInBox('c', 'reviewing'),
+    ];
+    expect(availableRegisters(items)).toEqual(['comfortable', 'narrow']);
+  });
+
+  it('unlocks "wide" once ≥ 6 items are in reviewing or mastered', () => {
+    const items = Array.from({ length: 6 }, (_, i) => itemInBox(String(i), 'mastered'));
+    expect([...availableRegisters(items)].sort()).toEqual(['comfortable', 'narrow', 'wide']);
+  });
+
+  it('returns "comfortable" only when the list is empty', () => {
+    expect(availableRegisters([])).toEqual(['comfortable']);
+  });
+});

--- a/packages/core/tests/variability/pickers.test.ts
+++ b/packages/core/tests/variability/pickers.test.ts
@@ -57,3 +57,29 @@ describe('pickRegister', () => {
     expect(result).toBe('wide');
   });
 });
+
+describe('pickRegister — available parameter', () => {
+  it('picks only from the available list when provided', () => {
+    const rng = () => 0.5;
+    const history = { lastTimbre: null, lastRegister: null };
+    const settings = { lockedTimbre: null, lockedRegister: null };
+    for (let i = 0; i < 20; i++) {
+      const r = pickRegister(rng, history, settings, ['comfortable']);
+      expect(r).toBe('comfortable');
+    }
+  });
+
+  it('respects lockedRegister when it appears in the available list', () => {
+    const rng = () => 0.5;
+    const history = { lastTimbre: null, lastRegister: null };
+    const settings = { lockedTimbre: null, lockedRegister: 'narrow' as const };
+    expect(pickRegister(rng, history, settings, ['comfortable', 'narrow'])).toBe('narrow');
+  });
+
+  it('ignores lockedRegister when it is NOT in the available list', () => {
+    const rng = () => 0.5;
+    const history = { lastTimbre: null, lastRegister: null };
+    const settings = { lockedTimbre: null, lockedRegister: 'wide' as const };
+    expect(pickRegister(rng, history, settings, ['comfortable'])).toBe('comfortable');
+  });
+});


### PR DESCRIPTION
## Summary
Unlocks \`narrow\` and \`wide\` registers gradually as items advance to reviewing/mastered. Constrains \`pickRegister()\` via an optional \`available\` list.

## Screenshots
N/A — not UI.

## Test plan
- [x] \`pnpm --filter @ear-training/core test register-gating\` — 4 new tests
- [x] \`pnpm --filter @ear-training/core test variability/pickers\` — 3 new tests + existing coverage still green
- [x] \`pnpm run typecheck && pnpm run test\` — full suite green

## Plan reference
Part of Plan C1.1, Task 5. See \`docs/plans/2026-04-16-plan-c1-1-foundation-additions.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)