### PR TITLE
feat(web-platform): AudioBufferRecorder via AudioWorklet

### DIFF
--- a/packages/web-platform/src/mic/recorder-worklet.ts
+++ b/packages/web-platform/src/mic/recorder-worklet.ts
@@ -1,0 +1,65 @@
+/**
+ * Produces the source code for the AudioBufferRecorder worklet as a string,
+ * to be registered via audioWorklet.addModule(URL.createObjectURL(Blob)).
+ *
+ * The worklet maintains a preallocated Float32 ring buffer sized for
+ * maxDurationSec * sampleRate samples. On 'start', write pointer resets;
+ * every process() call writes mono (first channel) input samples into the
+ * ring, stopping at capacity. On 'stop', the worklet posts the buffer
+ * slice back to the main thread.
+ *
+ * Allocation-free in process() — follows the YIN worklet discipline.
+ */
+export function buildRecorderWorkletSource(maxDurationSec: number): string {
+  return `
+class RecorderProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+    const sampleRate = globalThis.sampleRate;
+    this.capacity = Math.ceil(${maxDurationSec} * sampleRate);
+    this.ring = new Float32Array(this.capacity);
+    this.writeIndex = 0;
+    this.recording = false;
+    this.port.onmessage = (e) => {
+      if (e.data.type === 'start') {
+        this.writeIndex = 0;
+        this.recording = true;
+      } else if (e.data.type === 'stop') {
+        this.recording = false;
+        const snapshot = this.ring.slice(0, this.writeIndex);
+        this.port.postMessage({
+          type: 'snapshot',
+          samples: snapshot,
+          writtenSamples: this.writeIndex,
+        }, [snapshot.buffer]);
+      }
+    };
+  }
+
+  process(inputs) {
+    if (!this.recording) return true;
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+    const channel = input[0];
+    const remaining = this.capacity - this.writeIndex;
+    const toCopy = Math.min(channel.length, remaining);
+    for (let i = 0; i < toCopy; i++) {
+      this.ring[this.writeIndex + i] = channel[i];
+    }
+    this.writeIndex += toCopy;
+    if (this.writeIndex >= this.capacity) {
+      this.recording = false;
+      const snapshot = this.ring.slice(0, this.writeIndex);
+      this.port.postMessage({
+        type: 'snapshot',
+        samples: snapshot,
+        writtenSamples: this.writeIndex,
+      }, [snapshot.buffer]);
+    }
+    return true;
+  }
+}
+
+registerProcessor('audio-buffer-recorder', RecorderProcessor);
+  `;
+}

--- a/packages/web-platform/src/mic/recorder.ts
+++ b/packages/web-platform/src/mic/recorder.ts
@@ -1,0 +1,72 @@
+import { buildRecorderWorkletSource } from './recorder-worklet';
+
+export interface StartAudioRecorderInput {
+  audioContext: AudioContext;
+  micStream: MediaStream;
+  maxDurationSec?: number;
+}
+
+export interface RecorderHandle {
+  start(): void;
+  stop(): Promise<AudioBuffer>;
+  dispose(): void;
+  _portForTest?(): MessagePort;
+}
+
+const moduleLoadedFor: WeakSet<AudioContext> = new WeakSet();
+
+export async function startAudioRecorder(
+  input: StartAudioRecorderInput,
+): Promise<RecorderHandle> {
+  const { audioContext, micStream, maxDurationSec = 6 } = input;
+
+  if (!moduleLoadedFor.has(audioContext)) {
+    const source = buildRecorderWorkletSource(maxDurationSec);
+    const blob = new Blob([source], { type: 'application/javascript' });
+    const url = URL.createObjectURL(blob);
+    await audioContext.audioWorklet.addModule(url);
+    moduleLoadedFor.add(audioContext);
+  }
+
+  const node = new AudioWorkletNode(audioContext, 'audio-buffer-recorder');
+  const micSource = audioContext.createMediaStreamSource(micStream);
+  micSource.connect(node);
+
+  let pendingResolve: ((buf: AudioBuffer) => void) | null = null;
+
+  node.port.onmessage = (ev) => {
+    if (ev.data?.type !== 'snapshot') return;
+    const samples: Float32Array<ArrayBuffer> = ev.data.samples;
+    const written: number = ev.data.writtenSamples;
+    const length = Math.max(1, written);
+    const buffer = audioContext.createBuffer(1, length, audioContext.sampleRate);
+    buffer.copyToChannel(samples.subarray(0, length), 0);
+    pendingResolve?.(buffer);
+    pendingResolve = null;
+  };
+
+  let disposed = false;
+
+  return {
+    start() {
+      if (disposed) throw new Error('recorder disposed');
+      node.port.postMessage({ type: 'start' });
+    },
+    stop(): Promise<AudioBuffer> {
+      if (disposed) throw new Error('recorder disposed');
+      return new Promise<AudioBuffer>((resolve) => {
+        pendingResolve = resolve;
+        node.port.postMessage({ type: 'stop' });
+      });
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      try { node.disconnect(); } catch { /* already disconnected */ }
+      try { micSource.disconnect(); } catch { /* already disconnected */ }
+    },
+    _portForTest() {
+      return node.port as unknown as MessagePort;
+    },
+  };
+}

--- a/packages/web-platform/tests/mic/recorder.test.ts
+++ b/packages/web-platform/tests/mic/recorder.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { startAudioRecorder } from '@/mic/recorder';
+
+// jsdom has no AudioWorklet — we mock the shape the module uses.
+class FakeAudioWorkletNode extends EventTarget {
+  port = {
+    onmessage: null as ((ev: MessageEvent) => void) | null,
+    postMessage: vi.fn(),
+  };
+  disconnect = vi.fn();
+  constructor(public ctx: AudioContext, public name: string, public opts?: AudioWorkletNodeOptions) {
+    super();
+  }
+}
+
+function makeFakeContext(): AudioContext {
+  const audioWorklet = { addModule: vi.fn(async () => undefined) };
+  const createBuffer = vi.fn((channels: number, length: number, sampleRate: number) => ({
+    numberOfChannels: channels,
+    length,
+    sampleRate,
+    getChannelData: vi.fn(() => new Float32Array(length)),
+    copyToChannel: vi.fn(),
+  })) as unknown as AudioContext['createBuffer'];
+
+  const createMediaStreamSource = vi.fn(() => ({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  })) as unknown as AudioContext['createMediaStreamSource'];
+
+  return {
+    sampleRate: 48000,
+    audioWorklet,
+    createBuffer,
+    createMediaStreamSource,
+  } as unknown as AudioContext;
+}
+
+function makeFakeMicStream(): MediaStream {
+  return {} as MediaStream;
+}
+
+beforeEach(() => {
+  // @ts-expect-error install the fake constructor globally
+  globalThis.AudioWorkletNode = FakeAudioWorkletNode;
+  // jsdom does not implement URL.createObjectURL — stub it out.
+  // The recorder uses it only to pass a URL string to addModule(); since
+  // addModule is itself mocked, the value of the URL doesn't matter.
+  globalThis.URL.createObjectURL = vi.fn(() => 'blob:fake');
+});
+
+describe('AudioBufferRecorder', () => {
+  it('loads the recorder worklet module once and returns a handle', async () => {
+    const ctx = makeFakeContext();
+    const stream = makeFakeMicStream();
+    const handle = await startAudioRecorder({ audioContext: ctx, micStream: stream, maxDurationSec: 6 });
+    expect(ctx.audioWorklet.addModule).toHaveBeenCalledTimes(1);
+    expect(typeof handle.start).toBe('function');
+    expect(typeof handle.stop).toBe('function');
+    expect(typeof handle.dispose).toBe('function');
+  });
+
+  it('start() does not throw with a fresh handle', async () => {
+    const ctx = makeFakeContext();
+    const handle = await startAudioRecorder({
+      audioContext: ctx, micStream: makeFakeMicStream(), maxDurationSec: 6,
+    });
+    expect(() => handle.start()).not.toThrow();
+  });
+
+  it('stop() resolves with an AudioBuffer whose sampleRate matches the AudioContext', async () => {
+    const ctx = makeFakeContext();
+    const handle = await startAudioRecorder({
+      audioContext: ctx, micStream: makeFakeMicStream(), maxDurationSec: 6,
+    });
+
+    handle.start();
+    const stopPromise = handle.stop();
+    // Grab the port via the test hook and simulate the worklet's snapshot response.
+    const port = handle._portForTest?.();
+    if (port?.onmessage) {
+      const samples = new Float32Array(1024);
+      port.onmessage({ data: { type: 'snapshot', samples, writtenSamples: 500 } } as MessageEvent);
+    }
+    const buffer = await stopPromise;
+    expect(buffer.sampleRate).toBe(48000);
+    expect(buffer.length).toBeGreaterThan(0);
+    expect(buffer.length).toBeLessThanOrEqual(500);
+  });
+
+  it('dispose() disconnects the worklet without throwing', async () => {
+    const ctx = makeFakeContext();
+    const handle = await startAudioRecorder({
+      audioContext: ctx, micStream: makeFakeMicStream(), maxDurationSec: 6,
+    });
+    expect(() => handle.dispose()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
New \`startAudioRecorder({ audioContext, micStream, maxDurationSec })\` returns a handle with \`start() / stop() / dispose()\`. \`stop()\` resolves with an \`AudioBuffer\` sliced from a preallocated Float32 ring buffer.

One divergence from the plan spec: added \`URL.createObjectURL = vi.fn(() => 'blob:fake')\` to the test's \`beforeEach\` (alongside the existing \`AudioWorkletNode\` mock) because jsdom doesn't implement that API. The \`addModule\` call is already mocked, so the stubbed URL value is irrelevant to correctness. Also typed \`samples\` as \`Float32Array<ArrayBuffer>\` (not the looser \`Float32Array\`) to satisfy \`copyToChannel\`'s strict overload in TS 5.x.

## Screenshots
N/A — not UI.

## Test plan
- [x] \`pnpm --filter @ear-training/web-platform exec vitest run tests/mic/recorder.test.ts\` — 4 tests pass
- [x] \`pnpm run typecheck && pnpm run test\` — 240 tests, all green

## Plan reference
Part of Plan C1.1, Task 6 (final task of this sub-plan). See \`docs/plans/2026-04-16-plan-c1-1-foundation-additions.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)