### PR TITLE
feat(exercise): SessionController scaffold

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,15 +43,17 @@ apps/**, CSS/tokens affecting rendering, any route). Otherwise write "N/A — no
 Headless workflow for subagent-generated PRs: capture via Playwright in the task's
 e2e spec, save under docs/screenshots/c1-<N>/taskN-<slug>/<description>.png,
 commit with the PR, then reference the file using an ABSOLUTE raw.githubusercontent
-URL with the branch interpolated at PR-creation time. Relative paths like
+URL with the commit SHA captured at PR-creation time. Relative paths like
 ../../docs/... do NOT work in PR bodies — GitHub resolves them against /pull/N/,
-not the repo root (see github/markup#576). The raw URL form works for both
-in-review PRs (pointing at the PR branch) and post-merge viewers.
+not the repo root (see github/markup#576). The SHA-based URL form works for both
+in-review PRs (commit exists on the PR branch) and post-merge viewers (commit
+persists in git history). The SHA-based URL survives squash-merge + branch
+deletion; the branch-based URL does not.
 
 Pattern (inside a subagent bash HEREDOC):
 
-    BRANCH=$(git rev-parse --abbrev-ref HEAD)
-    gh pr create --body "... ![feedback on pass](https://raw.githubusercontent.com/julianken/ear-training-station/$BRANCH/docs/screenshots/c1-3/task7-feedback-panel/pass-state.png) ..."
+    SHA=$(git rev-parse HEAD)
+    gh pr create --body "... ![feedback on pass](https://raw.githubusercontent.com/julianken/ear-training-station/${SHA}/docs/screenshots/c1-3/task7-feedback-panel/pass-state.png) ..."
 
 Human-authored PRs can drag-and-drop the image directly into the comment box —
 GitHub uploads it and inserts a working link. -->

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/index.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/index.ts
@@ -12,4 +12,5 @@ export const manifest: ExerciseManifest = {
   route: '/scale-degree',
 };
 
-// C1.3 will add: createSessionController, SessionView, DashboardView, DashboardWidget.
+export { createSessionController } from './internal/session-controller.svelte';
+export type { SessionController, SessionControllerDeps } from './internal/session-controller.svelte';

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -86,8 +86,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
         this.#captureEndTimer = null;
       }
       this.#playHandle?.cancel();
-      void this.#pitchHandle?.stop();
-      void this.#kwsHandle?.stop();
+      this.#pitchHandle?.stop().catch(() => {});
+      this.#kwsHandle?.stop().catch(() => {});
       this.#recorderHandle?.dispose();
       this.#playHandle = null;
       this.#pitchHandle = null;

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -1,0 +1,104 @@
+import { roundReducer } from '@ear-training/core/round/state';
+import type { RoundState } from '@ear-training/core/round/state';
+import type { RoundEvent } from '@ear-training/core/round/events';
+import type { Item, Session } from '@ear-training/core/types/domain';
+import type {
+  ItemsRepo, AttemptsRepo, SessionsRepo, SettingsRepo,
+} from '@ear-training/core/repos/interfaces';
+import type { PlayRoundHandle } from '@ear-training/web-platform/audio/player';
+import type { PitchDetectorHandle } from '@ear-training/web-platform/pitch/pitch-detector';
+import type { KeywordSpotterHandle } from '@ear-training/web-platform/speech/keyword-spotter';
+import type { RecorderHandle } from '@ear-training/web-platform/mic/recorder';
+
+export interface SessionControllerDeps {
+  session: Session;
+  firstItem: Item;
+  itemsRepo: ItemsRepo;
+  attemptsRepo: AttemptsRepo;
+  sessionsRepo: SessionsRepo;
+  settingsRepo: SettingsRepo;
+  getAudioContext: () => AudioContext;
+  getMicStream: () => Promise<MediaStream>;
+}
+
+export interface SessionController {
+  readonly state: RoundState;
+  readonly session: Session | null;
+  readonly currentItem: Item | null;
+  readonly capturedAudio: AudioBuffer | null;
+  readonly targetAudio: AudioBuffer | null;
+  startRound(): Promise<void>;
+  cancelRound(): void;
+  next(): Promise<void>;
+  dispose(): void;
+  /** @internal — test hook */
+  _forceState(state: RoundState): void;
+}
+
+export function createSessionController(deps: SessionControllerDeps): SessionController {
+  class ControllerImpl implements SessionController {
+    state = $state<RoundState>({ kind: 'idle' });
+    session = $state<Session | null>(deps.session);
+    currentItem = $state<Item | null>(deps.firstItem);
+    capturedAudio = $state<AudioBuffer | null>(null);
+    targetAudio = $state<AudioBuffer | null>(null);
+
+    #playHandle: PlayRoundHandle | null = null;
+    #pitchHandle: PitchDetectorHandle | null = null;
+    #kwsHandle: KeywordSpotterHandle | null = null;
+    #recorderHandle: RecorderHandle | null = null;
+    #captureEndTimer: number | null = null;
+    #disposed = false;
+
+    #dispatch(event: RoundEvent): void {
+      this.state = roundReducer(this.state, event);
+      this.#onStateChange();
+    }
+
+    #onStateChange(): void {
+      // Task 6 installs the capture-end watcher here.
+    }
+
+    async startRound(): Promise<void> {
+      if (this.#disposed) return;
+      throw new Error('not implemented — see C1.3 Task 6');
+    }
+
+    cancelRound(): void {
+      if (this.#disposed) return;
+      this.#dispatch({ type: 'USER_CANCELED', at_ms: Date.now() });
+      this.#stopAudioHandles();
+    }
+
+    async next(): Promise<void> {
+      throw new Error('not implemented — see C1.3 Task 6');
+    }
+
+    dispose(): void {
+      if (this.#disposed) return;
+      this.#disposed = true;
+      this.#stopAudioHandles();
+    }
+
+    #stopAudioHandles(): void {
+      if (this.#captureEndTimer != null) {
+        clearTimeout(this.#captureEndTimer);
+        this.#captureEndTimer = null;
+      }
+      this.#playHandle?.cancel();
+      void this.#pitchHandle?.stop();
+      void this.#kwsHandle?.stop();
+      this.#recorderHandle?.dispose();
+      this.#playHandle = null;
+      this.#pitchHandle = null;
+      this.#kwsHandle = null;
+      this.#recorderHandle = null;
+    }
+
+    _forceState(state: RoundState): void {
+      this.state = state;
+    }
+  }
+
+  return new ControllerImpl();
+}

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionController } from './session-controller.svelte';
+import type { Item, Session } from '@ear-training/core/types/domain';
+
+const baseItem: Item = {
+  id: '5-C-major',
+  degree: 5,
+  key: { tonic: 'C', quality: 'major' },
+  box: 'new',
+  accuracy: { pitch: 0, label: 0 },
+  recent: [],
+  attempts: 0,
+  consecutive_passes: 0,
+  last_seen_at: null,
+  due_at: 0,
+  created_at: 0,
+};
+
+const baseSession: Session = {
+  id: 'sess-1',
+  started_at: 0,
+  ended_at: null,
+  target_items: 30,
+  completed_items: 0,
+  pitch_pass_count: 0,
+  label_pass_count: 0,
+  focus_item_id: null,
+};
+
+function makeDeps() {
+  return {
+    session: baseSession,
+    firstItem: baseItem,
+    itemsRepo: { get: vi.fn(), listAll: vi.fn(async () => []), findDue: vi.fn(async () => [baseItem]), findByBox: vi.fn(), put: vi.fn(), putMany: vi.fn() },
+    attemptsRepo: { append: vi.fn(), findBySession: vi.fn(async () => []), findByItem: vi.fn() },
+    sessionsRepo: { start: vi.fn(), complete: vi.fn(), get: vi.fn(async () => baseSession), findRecent: vi.fn() },
+    settingsRepo: { getOrDefault: vi.fn(async () => ({ function_tooltip: true, auto_advance_on_hit: true, session_length: 30, reduced_motion: 'auto' as const, onboarded: true })), update: vi.fn() },
+    getAudioContext: () => new (class { currentTime = 0; sampleRate = 48000; audioWorklet = { addModule: vi.fn(async () => undefined) }; createBuffer() { return {} as AudioBuffer; } createMediaStreamSource() { return { connect: vi.fn(), disconnect: vi.fn() }; } })() as unknown as AudioContext,
+    getMicStream: async () => ({} as MediaStream),
+  };
+}
+
+describe('SessionController', () => {
+  it('starts in idle state', () => {
+    const ctrl = createSessionController(makeDeps());
+    expect(ctrl.state.kind).toBe('idle');
+  });
+
+  it('exposes session and currentItem', () => {
+    const ctrl = createSessionController(makeDeps());
+    expect(ctrl.session?.id).toBe('sess-1');
+    expect(ctrl.currentItem?.id).toBe('5-C-major');
+  });
+
+  it('cancelRound() dispatches USER_CANCELED', () => {
+    const ctrl = createSessionController(makeDeps());
+    ctrl._forceState({ kind: 'playing_cadence', item: baseItem, timbre: 'piano', register: 'comfortable', startedAt: 0 } as never);
+    ctrl.cancelRound();
+    expect(ctrl.state.kind).toBe('idle');
+  });
+
+  it('dispose() is idempotent', () => {
+    const ctrl = createSessionController(makeDeps());
+    ctrl.dispose();
+    expect(() => ctrl.dispose()).not.toThrow();
+  });
+});

--- a/docs/plans/2026-04-16-plan-c1-2-sveltekit-shell.md
+++ b/docs/plans/2026-04-16-plan-c1-2-sveltekit-shell.md
@@ -16,7 +16,7 @@
 
 **PR body requirements — screenshots + mermaid for UI tasks:** every PR in this plan that adds or modifies visible UI (any `.svelte` file, CSS/tokens affecting rendering, any route) MUST include at least one screenshot referenced in the PR body. When architecture, flow, state machine, component tree, or navigation graph clarifies the change, embed a mermaid diagram in the PR body using a ```mermaid fenced block. GitHub renders mermaid inline.
 
-**Headless-friendly screenshot workflow for implementer subagents:** capture the screenshot directly from a Playwright script (reusing the task's own e2e spec is ideal — it already drives the flow), save the PNG to `docs/screenshots/c1-2/taskN-<slug>/<description>.png`, commit it with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the branch interpolated at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root — see [github/markup#576](https://github.com/github/markup/issues/576)); the raw URL form works for both in-review PRs (pointing at the PR branch) and post-merge viewers (point at `main`).
+**Headless-friendly screenshot workflow for implementer subagents:** capture the screenshot directly from a Playwright script (reusing the task's own e2e spec is ideal — it already drives the flow), save the PNG to `docs/screenshots/c1-2/taskN-<slug>/<description>.png`, commit it with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the commit SHA captured at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root — see [github/markup#576](https://github.com/github/markup/issues/576)); the SHA-based URL form works for both in-review PRs (commit exists on the PR branch) and post-merge viewers (commit persists in git history). The SHA-based URL survives squash-merge + branch deletion; the branch-based URL does not.
 
 Example snippet inside the e2e spec:
 
@@ -25,12 +25,12 @@ Example snippet inside the e2e spec:
 await page.screenshot({ path: 'docs/screenshots/c1-2/task3-station-dashboard/picker.png', fullPage: true });
 ```
 
-And in the commit/push step, interpolate the branch when building the PR body:
+And in the commit/push step, capture the SHA and interpolate it when building the PR body:
 
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SHA=$(git rev-parse HEAD)
 gh pr create --body "...
-![picker](https://raw.githubusercontent.com/julianken/ear-training-station/$BRANCH/docs/screenshots/c1-2/task3-station-dashboard/picker.png)
+![picker](https://raw.githubusercontent.com/julianken/ear-training-station/${SHA}/docs/screenshots/c1-2/task3-station-dashboard/picker.png)
 ..."
 ```
 

--- a/docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md
+++ b/docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md
@@ -18,7 +18,7 @@
 
 Where it helps explain the change, embed a mermaid diagram using a ```mermaid fenced block — GitHub renders it inline. High-value mermaid candidates in this plan: the round-reducer state machine (for Task 6's CAPTURE_COMPLETE wiring), the component tree inside `ActiveRound`, event-dispatch sequences, navigation between session / summary / dashboard.
 
-**Headless-friendly screenshot workflow for implementer subagents:** capture the screenshot directly from a Playwright script (reusing the task's own e2e spec is ideal — it already drives the flow), save the PNG to `docs/screenshots/c1-3/taskN-<slug>/<description>.png`, commit it with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the branch interpolated at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root); the raw URL form works for both in-review PRs and post-merge viewers.
+**Headless-friendly screenshot workflow for implementer subagents:** capture the screenshot directly from a Playwright script (reusing the task's own e2e spec is ideal — it already drives the flow), save the PNG to `docs/screenshots/c1-3/taskN-<slug>/<description>.png`, commit it with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the commit SHA captured at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root); the SHA-based URL form works for both in-review PRs (commit exists on the PR branch) and post-merge viewers (commit persists in git history). The SHA-based URL survives squash-merge + branch deletion; the branch-based URL does not.
 
 Example snippet in the e2e spec:
 
@@ -29,9 +29,9 @@ await page.screenshot({ path: 'docs/screenshots/c1-3/task7-feedback-panel/pass-s
 And in the PR-creation step:
 
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SHA=$(git rev-parse HEAD)
 gh pr create --body "...
-![feedback on pass](https://raw.githubusercontent.com/julianken/ear-training-station/$BRANCH/docs/screenshots/c1-3/task7-feedback-panel/pass-state.png)
+![feedback on pass](https://raw.githubusercontent.com/julianken/ear-training-station/${SHA}/docs/screenshots/c1-3/task7-feedback-panel/pass-state.png)
 ..."
 ```
 

--- a/docs/plans/2026-04-16-plan-c1-4-error-ux-pwa-delivery.md
+++ b/docs/plans/2026-04-16-plan-c1-4-error-ux-pwa-delivery.md
@@ -16,7 +16,7 @@
 
 **PR body requirements — screenshots + mermaid for UI tasks:** every PR in Tasks 1–3 (MicDeniedGate, DegradationBanner, ShellToast) MUST include at least one screenshot referenced in the PR body showing the component in its triggered state. Task 4 (service worker) should include a mermaid flowchart of the cache strategy (precache flow + runtime-cache flow for the KWS model). Task 5 (axe a11y) and Task 6 (bundle budget) ship text-only PRs — screenshots not required, but mermaid diagrams welcome if they clarify flows. Task 7 (small config cleanup) is text-only.
 
-**Headless-friendly screenshot workflow for implementer subagents:** capture from a Playwright script (reusing the task's own e2e spec), save to `docs/screenshots/c1-4/taskN-<slug>/<description>.png`, commit with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the branch interpolated at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root); the raw URL form works for both in-review PRs and post-merge viewers.
+**Headless-friendly screenshot workflow for implementer subagents:** capture from a Playwright script (reusing the task's own e2e spec), save to `docs/screenshots/c1-4/taskN-<slug>/<description>.png`, commit with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the commit SHA captured at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root); the SHA-based URL form works for both in-review PRs (commit exists on the PR branch) and post-merge viewers (commit persists in git history). The SHA-based URL survives squash-merge + branch deletion; the branch-based URL does not.
 
 Example for Task 1:
 
@@ -28,9 +28,9 @@ await page.screenshot({ path: 'docs/screenshots/c1-4/task1-mic-denied-gate/denie
 And in the PR-creation step:
 
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SHA=$(git rev-parse HEAD)
 gh pr create --body "...
-![mic denied gate](https://raw.githubusercontent.com/julianken/ear-training-station/$BRANCH/docs/screenshots/c1-4/task1-mic-denied-gate/denied-state.png)
+![mic denied gate](https://raw.githubusercontent.com/julianken/ear-training-station/${SHA}/docs/screenshots/c1-4/task1-mic-denied-gate/denied-state.png)
 ..."
 ```
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,9 +20,21 @@ export default tseslint.config(
   // Svelte support (activates only on .svelte files)
   ...svelte.configs['flat/recommended'],
 
-  // Svelte + TypeScript integration
+  // Svelte + TypeScript integration (*.svelte files)
   {
     files: ['**/*.svelte'],
+    languageOptions: {
+      parserOptions: {
+        parser: tseslint.parser,
+      },
+    },
+  },
+
+  // Svelte 5 runes in *.svelte.ts files — svelte.configs['flat/recommended'] already sets
+  // svelte-eslint-parser as the outer parser for these files; we only need to configure
+  // the inner TypeScript parser so $state/$derived/$effect are understood.
+  {
+    files: ['**/*.svelte.ts'],
     languageOptions: {
       parserOptions: {
         parser: tseslint.parser,


### PR DESCRIPTION
## Summary
Scaffolds the session controller class at `$lib/exercises/scale-degree/internal/session-controller.svelte.ts`. Svelte 5 runes (`$state`) for reactive fields; reducer-dispatch pipe wired; `cancelRound()` and `dispose()` implemented. `startRound()` and `next()` are stubs — Task 6 wires audio-handle lifecycle + CAPTURE_COMPLETE.

**Bundled fix (originally slated for PR #77):** also switches PR-body screenshot URLs in the PR template + three plan docs from `<branch>` to `<sha>` references. PR #75's screenshot broke post-merge because Mergify's squash strategy deleted the source branch; commit-SHA URLs survive branch deletion.

## Screenshots
N/A — not UI.

## Test plan
- [x] 4 unit tests for the SessionController (idle start, session/currentItem exposure, cancel→idle, dispose idempotent)
- [x] `.catch(() => {})` on pitch/KWS stop promises to avoid unhandled-rejection surface (cycle-1 IMPORTANT fix)
- [x] `pnpm run typecheck && pnpm run test && pnpm run build && pnpm run lint` — all green (262 tests)
- [x] Grep audit on the 4 updated doc files confirms zero remaining `\$BRANCH` / `<BRANCH>` / `rev-parse --abbrev-ref HEAD` references

## Plan reference
Plan C1.3 Task 1 (SessionController) + out-of-plan tooling fix (SHA URLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)