### PR TITLE
chore: switch screenshot URLs from branch ref to commit SHA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,15 +43,17 @@ apps/**, CSS/tokens affecting rendering, any route). Otherwise write "N/A — no
 Headless workflow for subagent-generated PRs: capture via Playwright in the task's
 e2e spec, save under docs/screenshots/c1-<N>/taskN-<slug>/<description>.png,
 commit with the PR, then reference the file using an ABSOLUTE raw.githubusercontent
-URL with the branch interpolated at PR-creation time. Relative paths like
+URL with the commit SHA captured at PR-creation time. Relative paths like
 ../../docs/... do NOT work in PR bodies — GitHub resolves them against /pull/N/,
-not the repo root (see github/markup#576). The raw URL form works for both
-in-review PRs (pointing at the PR branch) and post-merge viewers.
+not the repo root (see github/markup#576). The SHA-based URL form works for both
+in-review PRs (commit exists on the PR branch) and post-merge viewers (commit
+persists in git history). The SHA-based URL survives squash-merge + branch
+deletion; the branch-based URL does not.
 
 Pattern (inside a subagent bash HEREDOC):
 
-    BRANCH=$(git rev-parse --abbrev-ref HEAD)
-    gh pr create --body "... ![feedback on pass](https://raw.githubusercontent.com/julianken/ear-training-station/$BRANCH/docs/screenshots/c1-3/task7-feedback-panel/pass-state.png) ..."
+    SHA=$(git rev-parse HEAD)
+    gh pr create --body "... ![feedback on pass](https://raw.githubusercontent.com/julianken/ear-training-station/${SHA}/docs/screenshots/c1-3/task7-feedback-panel/pass-state.png) ..."
 
 Human-authored PRs can drag-and-drop the image directly into the comment box —
 GitHub uploads it and inserts a working link. -->

--- a/docs/plans/2026-04-16-plan-c1-2-sveltekit-shell.md
+++ b/docs/plans/2026-04-16-plan-c1-2-sveltekit-shell.md
@@ -16,7 +16,7 @@
 
 **PR body requirements — screenshots + mermaid for UI tasks:** every PR in this plan that adds or modifies visible UI (any `.svelte` file, CSS/tokens affecting rendering, any route) MUST include at least one screenshot referenced in the PR body. When architecture, flow, state machine, component tree, or navigation graph clarifies the change, embed a mermaid diagram in the PR body using a ```mermaid fenced block. GitHub renders mermaid inline.
 
-**Headless-friendly screenshot workflow for implementer subagents:** capture the screenshot directly from a Playwright script (reusing the task's own e2e spec is ideal — it already drives the flow), save the PNG to `docs/screenshots/c1-2/taskN-<slug>/<description>.png`, commit it with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the branch interpolated at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root — see [github/markup#576](https://github.com/github/markup/issues/576)); the raw URL form works for both in-review PRs (pointing at the PR branch) and post-merge viewers (point at `main`).
+**Headless-friendly screenshot workflow for implementer subagents:** capture the screenshot directly from a Playwright script (reusing the task's own e2e spec is ideal — it already drives the flow), save the PNG to `docs/screenshots/c1-2/taskN-<slug>/<description>.png`, commit it with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the commit SHA captured at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root — see [github/markup#576](https://github.com/github/markup/issues/576)); the SHA-based URL form works for both in-review PRs (commit exists on the PR branch) and post-merge viewers (commit persists in git history). The SHA-based URL survives squash-merge + branch deletion; the branch-based URL does not.
 
 Example snippet inside the e2e spec:
 
@@ -25,12 +25,12 @@ Example snippet inside the e2e spec:
 await page.screenshot({ path: 'docs/screenshots/c1-2/task3-station-dashboard/picker.png', fullPage: true });
 ```
 
-And in the commit/push step, interpolate the branch when building the PR body:
+And in the commit/push step, capture the SHA and interpolate it when building the PR body:
 
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SHA=$(git rev-parse HEAD)
 gh pr create --body "...
-![picker](https://raw.githubusercontent.com/julianken/ear-training-station/$BRANCH/docs/screenshots/c1-2/task3-station-dashboard/picker.png)
+![picker](https://raw.githubusercontent.com/julianken/ear-training-station/${SHA}/docs/screenshots/c1-2/task3-station-dashboard/picker.png)
 ..."
 ```
 

--- a/docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md
+++ b/docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md
@@ -18,7 +18,7 @@
 
 Where it helps explain the change, embed a mermaid diagram using a ```mermaid fenced block — GitHub renders it inline. High-value mermaid candidates in this plan: the round-reducer state machine (for Task 6's CAPTURE_COMPLETE wiring), the component tree inside `ActiveRound`, event-dispatch sequences, navigation between session / summary / dashboard.
 
-**Headless-friendly screenshot workflow for implementer subagents:** capture the screenshot directly from a Playwright script (reusing the task's own e2e spec is ideal — it already drives the flow), save the PNG to `docs/screenshots/c1-3/taskN-<slug>/<description>.png`, commit it with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the branch interpolated at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root); the raw URL form works for both in-review PRs and post-merge viewers.
+**Headless-friendly screenshot workflow for implementer subagents:** capture the screenshot directly from a Playwright script (reusing the task's own e2e spec is ideal — it already drives the flow), save the PNG to `docs/screenshots/c1-3/taskN-<slug>/<description>.png`, commit it with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the commit SHA captured at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root); the SHA-based URL form works for both in-review PRs (commit exists on the PR branch) and post-merge viewers (commit persists in git history). The SHA-based URL survives squash-merge + branch deletion; the branch-based URL does not.
 
 Example snippet in the e2e spec:
 
@@ -29,9 +29,9 @@ await page.screenshot({ path: 'docs/screenshots/c1-3/task7-feedback-panel/pass-s
 And in the PR-creation step:
 
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SHA=$(git rev-parse HEAD)
 gh pr create --body "...
-![feedback on pass](https://raw.githubusercontent.com/julianken/ear-training-station/$BRANCH/docs/screenshots/c1-3/task7-feedback-panel/pass-state.png)
+![feedback on pass](https://raw.githubusercontent.com/julianken/ear-training-station/${SHA}/docs/screenshots/c1-3/task7-feedback-panel/pass-state.png)
 ..."
 ```
 

--- a/docs/plans/2026-04-16-plan-c1-4-error-ux-pwa-delivery.md
+++ b/docs/plans/2026-04-16-plan-c1-4-error-ux-pwa-delivery.md
@@ -16,7 +16,7 @@
 
 **PR body requirements — screenshots + mermaid for UI tasks:** every PR in Tasks 1–3 (MicDeniedGate, DegradationBanner, ShellToast) MUST include at least one screenshot referenced in the PR body showing the component in its triggered state. Task 4 (service worker) should include a mermaid flowchart of the cache strategy (precache flow + runtime-cache flow for the KWS model). Task 5 (axe a11y) and Task 6 (bundle budget) ship text-only PRs — screenshots not required, but mermaid diagrams welcome if they clarify flows. Task 7 (small config cleanup) is text-only.
 
-**Headless-friendly screenshot workflow for implementer subagents:** capture from a Playwright script (reusing the task's own e2e spec), save to `docs/screenshots/c1-4/taskN-<slug>/<description>.png`, commit with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the branch interpolated at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root); the raw URL form works for both in-review PRs and post-merge viewers.
+**Headless-friendly screenshot workflow for implementer subagents:** capture from a Playwright script (reusing the task's own e2e spec), save to `docs/screenshots/c1-4/taskN-<slug>/<description>.png`, commit with the PR, and reference it in the PR body using an ABSOLUTE `raw.githubusercontent.com` URL with the commit SHA captured at PR-creation time. Relative paths like `../../docs/...` do **not** work in PR bodies (GitHub resolves them against `/pull/N/`, not the repo root); the SHA-based URL form works for both in-review PRs (commit exists on the PR branch) and post-merge viewers (commit persists in git history). The SHA-based URL survives squash-merge + branch deletion; the branch-based URL does not.
 
 Example for Task 1:
 
@@ -28,9 +28,9 @@ await page.screenshot({ path: 'docs/screenshots/c1-4/task1-mic-denied-gate/denie
 And in the PR-creation step:
 
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SHA=$(git rev-parse HEAD)
 gh pr create --body "...
-![mic denied gate](https://raw.githubusercontent.com/julianken/ear-training-station/$BRANCH/docs/screenshots/c1-4/task1-mic-denied-gate/denied-state.png)
+![mic denied gate](https://raw.githubusercontent.com/julianken/ear-training-station/${SHA}/docs/screenshots/c1-4/task1-mic-denied-gate/denied-state.png)
 ..."
 ```
 


### PR DESCRIPTION
## Summary
PR-body screenshots currently reference `raw.githubusercontent.com/<branch>/...` URLs, which 404 after Mergify squash-merges the PR and deletes the head ref. PR #75's screenshot broke this way post-merge. Commit-SHA URLs (`raw.githubusercontent.com/<sha>/...`) stay resolvable forever — the commit is reachable via git history regardless of what the branch ref does.

## Changes
- `.github/PULL_REQUEST_TEMPLATE.md` — Screenshots section uses `$SHA` from `git rev-parse HEAD` instead of `$BRANCH`
- C1.2 / C1.3 / C1.4 plan docs — same change in their "Headless-friendly screenshot workflow" sections

## Test plan
- [x] grep audit of the 4 files returns zero remaining `$BRANCH` / `<BRANCH>` / `rev-parse --abbrev-ref HEAD` references
- [x] Future subagent-generated PRs use the new pattern

## Plan reference
Out of plan — tooling fix discovered when PR #75's screenshot broke post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)