### PR TITLE
feat(exercise): PitchTrace

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchTrace.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchTrace.svelte
@@ -50,10 +50,11 @@
     return HEIGHT - frac * HEIGHT;
   }
 
-  // v1 visualization: plot sung pitch at the target-degree Y.
-  // The target band covers ±50¢ around the target, so deviations within that
-  // range visually "match". Richer rendering (actual degree from mapHzToDegree)
-  // is a future iteration. For MVP, band + on-band line conveys pass/fail.
+  // v1 visualization: plot confident sung frames at the target-degree Y.
+  // This conveys "we're hearing something" inside the match band but does NOT
+  // distinguish in-tune from out-of-tune — for any confident capture, the line
+  // sits on the band's centerline. Task 5/7 will wire mapHzToDegree so the
+  // polyline actually rises/falls off the band when pitch drifts sharp/flat.
   function hzToVisualDegree(hz: number): number {
     if (hz <= 0) return targetDegree;
     return targetDegree;

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchTrace.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchTrace.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import type { PitchObservation } from '@ear-training/core/round/grade-pitch';
+  import type { Degree } from '@ear-training/core/types/music';
+
+  const MIN_CONFIDENCE = 0.5;
+  const WIDTH = 480;
+  const HEIGHT = 160;
+  const BAND_HEIGHT_FRAC = 0.08;
+
+  let {
+    frames,
+    targetDegree,
+    windowStartMs,
+    windowDurationMs,
+    getCurrentTime,
+  }: {
+    frames: PitchObservation[];
+    targetDegree: Degree;
+    windowStartMs: number;
+    windowDurationMs: number;
+    getCurrentTime: () => number;
+  } = $props();
+
+  let now = $state(getCurrentTime());
+  let rafId: number | null = null;
+
+  function tick() {
+    now = getCurrentTime();
+    rafId = requestAnimationFrame(tick);
+  }
+  onMount(() => { rafId = requestAnimationFrame(tick); });
+  onDestroy(() => { if (rafId != null) cancelAnimationFrame(rafId); });
+
+  function timeToX(at_ms: number): number {
+    const t = (at_ms - windowStartMs) / windowDurationMs;
+    return Math.max(0, Math.min(1, t)) * WIDTH;
+  }
+
+  function degreeToY(degree: number): number {
+    const frac = (degree - 1) / 6;
+    return HEIGHT - frac * HEIGHT;
+  }
+
+  // v1 visualization: plot sung pitch at the target-degree Y.
+  // The target band covers ±50¢ around the target, so deviations within that
+  // range visually "match". Richer rendering (actual degree from mapHzToDegree)
+  // is a future iteration. For MVP, band + on-band line conveys pass/fail.
+  function hzToVisualDegree(hz: number): number {
+    if (hz <= 0) return targetDegree;
+    return targetDegree;
+  }
+
+  const points = $derived(
+    frames
+      .filter((f) => f.confidence >= MIN_CONFIDENCE && f.hz > 0)
+      .map((f) => `${timeToX(f.at_ms)},${degreeToY(hzToVisualDegree(f.hz))}`)
+      .join(' ')
+  );
+
+  const bandY = $derived(degreeToY(targetDegree) - (HEIGHT * BAND_HEIGHT_FRAC) / 2);
+  const bandH = HEIGHT * BAND_HEIGHT_FRAC;
+  const nowX = $derived(timeToX(now * 1000));
+</script>
+
+<svg class="pitch-trace" viewBox={`0 0 ${WIDTH} ${HEIGHT}`} width="100%" height={HEIGHT}>
+  <rect class="target-band" x="0" y={bandY} width={WIDTH} height={bandH} />
+  <polyline class="sung" {points} fill="none" />
+  <circle class="now-indicator" cx={nowX} cy={degreeToY(targetDegree)} r="4" />
+</svg>
+
+<style>
+  .pitch-trace {
+    background: #06101399;
+    border: 1px solid #171717;
+    border-radius: 6px;
+  }
+  .target-band {
+    fill: color-mix(in srgb, var(--cyan) 12%, transparent);
+    stroke: var(--cyan);
+    stroke-dasharray: 4 4;
+    stroke-width: 1;
+  }
+  .sung {
+    stroke: var(--amber);
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .now-indicator {
+    fill: var(--amber);
+    opacity: 0.9;
+  }
+</style>

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchTrace.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchTrace.svelte
@@ -13,20 +13,28 @@
     targetDegree,
     windowStartMs,
     windowDurationMs,
-    getCurrentTime,
+    getNowMs,
   }: {
     frames: PitchObservation[];
     targetDegree: Degree;
+    /** Wall-clock ms (same domain as `frames[i].at_ms` — i.e. `Date.now()`-style). */
     windowStartMs: number;
     windowDurationMs: number;
-    getCurrentTime: () => number;
+    /**
+     * Returns the current time in the SAME domain as `windowStartMs` and frame
+     * `at_ms` (i.e. wall-clock ms — typically `Date.now()`). If the parent is
+     * sourcing from an AudioContext, it must convert: multiply seconds by 1000
+     * and add the wall-clock offset captured when the context's clock was
+     * anchored. Mixing AC-seconds with wall-clock ms strands the "now" cursor.
+     */
+    getNowMs: () => number;
   } = $props();
 
-  let now = $state(getCurrentTime());
+  let nowMs = $state(getNowMs());
   let rafId: number | null = null;
 
   function tick() {
-    now = getCurrentTime();
+    nowMs = getNowMs();
     rafId = requestAnimationFrame(tick);
   }
   onMount(() => { rafId = requestAnimationFrame(tick); });
@@ -60,7 +68,7 @@
 
   const bandY = $derived(degreeToY(targetDegree) - (HEIGHT * BAND_HEIGHT_FRAC) / 2);
   const bandH = HEIGHT * BAND_HEIGHT_FRAC;
-  const nowX = $derived(timeToX(now * 1000));
+  const nowX = $derived(timeToX(nowMs));
 </script>
 
 <svg class="pitch-trace" viewBox={`0 0 ${WIDTH} ${HEIGHT}`} width="100%" height={HEIGHT}>

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchTrace.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchTrace.test.ts
@@ -9,7 +9,7 @@ describe('PitchTrace', () => {
       targetDegree: 5,
       windowStartMs: 0,
       windowDurationMs: 5000,
-      getCurrentTime: () => 0,
+      getNowMs: () => 0,
     });
     expect(container.querySelector('svg')).toBeTruthy();
     expect(container.querySelector('.target-band')).toBeTruthy();
@@ -26,7 +26,7 @@ describe('PitchTrace', () => {
       targetDegree: 5,
       windowStartMs: 0,
       windowDurationMs: 5000,
-      getCurrentTime: () => 0,
+      getNowMs: () => 0,
     });
     const polyline = container.querySelector('polyline.sung');
     const pointsAttr = polyline?.getAttribute('points') ?? '';
@@ -43,7 +43,7 @@ describe('PitchTrace', () => {
       targetDegree: 5,
       windowStartMs: 0,
       windowDurationMs: 5000,
-      getCurrentTime: () => 0,
+      getNowMs: () => 0,
     });
     const polyline = container.querySelector('polyline.sung');
     const pointsAttr = polyline?.getAttribute('points') ?? '';

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchTrace.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchTrace.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/svelte';
+import PitchTrace from './PitchTrace.svelte';
+
+describe('PitchTrace', () => {
+  it('renders an SVG with a target band and an empty polyline when no frames', () => {
+    const { container } = render(PitchTrace, {
+      frames: [],
+      targetDegree: 5,
+      windowStartMs: 0,
+      windowDurationMs: 5000,
+      getCurrentTime: () => 0,
+    });
+    expect(container.querySelector('svg')).toBeTruthy();
+    expect(container.querySelector('.target-band')).toBeTruthy();
+    const polyline = container.querySelector('polyline.sung');
+    expect(polyline?.getAttribute('points') ?? '').toBe('');
+  });
+
+  it('builds a polyline from confident frames', () => {
+    const { container } = render(PitchTrace, {
+      frames: [
+        { at_ms: 100, hz: 392, confidence: 0.9 },
+        { at_ms: 200, hz: 392, confidence: 0.9 },
+      ],
+      targetDegree: 5,
+      windowStartMs: 0,
+      windowDurationMs: 5000,
+      getCurrentTime: () => 0,
+    });
+    const polyline = container.querySelector('polyline.sung');
+    const pointsAttr = polyline?.getAttribute('points') ?? '';
+    expect(pointsAttr.split(' ').filter(Boolean).length).toBe(2);
+  });
+
+  it('skips frames with confidence below threshold', () => {
+    const { container } = render(PitchTrace, {
+      frames: [
+        { at_ms: 100, hz: 392, confidence: 0.9 },
+        { at_ms: 150, hz: 0, confidence: 0.1 },
+        { at_ms: 200, hz: 392, confidence: 0.9 },
+      ],
+      targetDegree: 5,
+      windowStartMs: 0,
+      windowDurationMs: 5000,
+      getCurrentTime: () => 0,
+    });
+    const polyline = container.querySelector('polyline.sung');
+    const pointsAttr = polyline?.getAttribute('points') ?? '';
+    expect(pointsAttr.split(' ').filter(Boolean).length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
SVG pitch-trace component for the session-screen bottom zone. Renders:
- Target tolerance band — cyan dashed rect, ±50¢ around the target degree's Y position
- Sung polyline — amber, plotting confident frames (`confidence >= 0.5 && hz > 0`)
- "Now" indicator — amber circle, position driven by rAF reading the wall-clock now

**v1 visualization scope:** `hzToVisualDegree` currently returns `targetDegree` for all confident frames — the polyline sits on the target band's centerline regardless of how in-tune the sung pitch is. This conveys "we're hearing something" but not match/miss; the band is the visual "match zone" and the polyline appears inside it for any confident capture. Richer rendering via `mapHzToDegree` (polyline rises/falls off the band when pitch drifts sharp/flat) is a known follow-up; Task 5 / Task 7 may backfill when composing ActiveRound and the feedback panel.

## Review history
- Cycle 1 (`aa0c53e`): initial implementation.
- Cycle 2 (`049a16d`): address @julianken-bot IMPORTANT — clock-domain contract. Renamed `getCurrentTime` → `getNowMs` with JSDoc spelling out wall-clock-ms requirement, dropped the stray `* 1000` that mixed AC-seconds with wall-clock ms.

## Screenshots
Deferred to Task 5 (ActiveRound) — PitchTrace is an isolated component without its own rendered route.

## Test plan
- [x] 3 component tests (empty polyline when no frames, polyline from confident frames, low-confidence frames skipped)
- [x] `pnpm run typecheck && pnpm run test && pnpm run build && pnpm run lint` — all green

## Plan reference
Part of Plan C1.3, Task 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)