### PR TITLE
feat(exercise): capture-end + CAPTURE_COMPLETE dispatch

### DIFF
--- a/apps/ear-training-station/e2e/round-graded.spec.ts
+++ b/apps/ear-training-station/e2e/round-graded.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import { seedOnboarded } from './helpers/app-state';
+
+// TODO(Task 7, Task 8): Un-skip once FeedbackPanel and ReplayBar are implemented.
+// This test seeds a graded state via the _forceState hook and verifies the UI
+// renders correctly. The components it expects (FeedbackPanel showing "pitch",
+// ReplayBar button named "target") do not exist until Tasks 7–8 land.
+test.skip('graded state renders FeedbackPanel and ReplayBar (seeded via test hook)', async ({ page, context }) => {
+  await context.grantPermissions(['microphone']);
+  await seedOnboarded(page);
+
+  // Seed an active session and a due item so the session route can construct a controller.
+  await page.addInitScript(() => {
+    return new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('ear-training', 1);
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => {
+        const db = req.result;
+        const tx = db.transaction(['sessions', 'items'], 'readwrite');
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        tx.objectStore('sessions').put({
+          id: 'test-sess',
+          started_at: Date.now(),
+          ended_at: null,
+          target_items: 30,
+          completed_items: 0,
+          pitch_pass_count: 0,
+          label_pass_count: 0,
+          focus_item_id: null,
+        });
+        // Seed at least one due item so the session route can construct a controller.
+        tx.objectStore('items').put({
+          id: '5-C-major',
+          degree: 5,
+          key: { tonic: 'C', quality: 'major' },
+          box: 'new',
+          accuracy: { pitch: 0, label: 0 },
+          recent: [],
+          attempts: 0,
+          consecutive_passes: 0,
+          last_seen_at: null,
+          due_at: Date.now() - 1000,
+          created_at: 0,
+        });
+      };
+    });
+  });
+
+  await page.goto('/scale-degree/sessions/test-sess');
+
+  // Wait for the controller to mount (ActiveRound renders a "Start" button in idle state).
+  await page.waitForFunction(() => {
+    // @ts-expect-error controller is exposed on window for e2e only
+    return window.__sessionControllerForTest != null;
+  });
+
+  // Force a graded state via the test hook.
+  await page.evaluate(() => {
+    // @ts-expect-error controller is exposed on window for e2e only
+    const ctrl = window.__sessionControllerForTest;
+    ctrl._forceState({
+      kind: 'graded',
+      item: ctrl.currentItem,
+      timbre: 'piano',
+      register: 'comfortable',
+      outcome: { pitch: true, label: true, pass: true, at: Date.now() },
+      cents_off: 4,
+      sungBest: { at_ms: 0, hz: 392, confidence: 0.95 },
+      digitHeard: 5,
+      digitConfidence: 0.9,
+    });
+  });
+
+  // FeedbackPanel (Task 7) renders pitch pass/fail info.
+  await expect(page.getByText(/pitch/i)).toBeVisible();
+  // ReplayBar (Task 8) renders a "Target" replay button.
+  await expect(page.getByRole('button', { name: /target/i })).toBeVisible();
+});

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -35,6 +35,8 @@ export interface SessionController {
   /** @internal — test hook */
   _forceState(state: RoundState): void;
   /** @internal — test hook */
+  _forceTimer(id: number): void;
+  /** @internal — test hook */
   _checkCaptureEnd(): void;
 }
 
@@ -59,6 +61,12 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       const curr = this.state.kind;
 
       if (prev === 'listening' && curr === 'graded') {
+        // Clear the 5-second capture-end timer so it doesn't fire during a
+        // future round if next() is called before the timeout expires.
+        if (this.#captureEndTimer != null) {
+          clearTimeout(this.#captureEndTimer);
+          this.#captureEndTimer = null;
+        }
         // Stop the recorder and attach the buffer
         if (this.#recorderHandle) {
           try {
@@ -197,6 +205,10 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
 
     _forceState(state: RoundState): void {
       this.state = state;
+    }
+
+    _forceTimer(id: number): void {
+      this.#captureEndTimer = id;
     }
   }
 

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -9,6 +9,7 @@ import type { PlayRoundHandle } from '@ear-training/web-platform/audio/player';
 import type { PitchDetectorHandle } from '@ear-training/web-platform/pitch/pitch-detector';
 import type { KeywordSpotterHandle } from '@ear-training/web-platform/speech/keyword-spotter';
 import type { RecorderHandle } from '@ear-training/web-platform/mic/recorder';
+import { gradeListeningState } from '@ear-training/core/round/grade-listening';
 
 export interface SessionControllerDeps {
   session: Session;
@@ -33,6 +34,8 @@ export interface SessionController {
   dispose(): void;
   /** @internal — test hook */
   _forceState(state: RoundState): void;
+  /** @internal — test hook */
+  _checkCaptureEnd(): void;
 }
 
 export function createSessionController(deps: SessionControllerDeps): SessionController {
@@ -50,23 +53,120 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     #captureEndTimer: number | null = null;
     #disposed = false;
 
-    #dispatch(event: RoundEvent): void {
+    async #dispatch(event: RoundEvent): Promise<void> {
+      const prev = this.state.kind;
       this.state = roundReducer(this.state, event);
+      const curr = this.state.kind;
+
+      if (prev === 'listening' && curr === 'graded') {
+        // Stop the recorder and attach the buffer
+        if (this.#recorderHandle) {
+          try {
+            this.capturedAudio = await this.#recorderHandle.stop();
+          } catch { /* ignore */ }
+        }
+      }
+
       this.#onStateChange();
     }
 
     #onStateChange(): void {
-      // Task 6 installs the capture-end watcher here.
+      if (this.state.kind === 'listening') {
+        this._checkCaptureEnd();
+      }
+    }
+
+    _checkCaptureEnd(): void {
+      if (this.state.kind !== 'listening') return;
+      const thresholds = { minPitchConfidence: 0.5, minDigitConfidence: 0.5 };
+      const grade = gradeListeningState(this.state, this.currentItem!, thresholds);
+      // Auto-advance on hit, if setting is on
+      // (settings will be threaded through via settingsSnapshot — simple default for now)
+      if (grade.outcome.pass) {
+        void this.#dispatch({ type: 'CAPTURE_COMPLETE', at_ms: Date.now(), grade });
+      }
+      // Capture timeout is handled in startRound() via a setTimeout to ~5s
+      // past PLAYBACK_DONE. If fired without a pass, dispatch CAPTURE_COMPLETE
+      // with whatever grade the state produces (may be fail).
     }
 
     async startRound(): Promise<void> {
       if (this.#disposed) return;
-      throw new Error('not implemented — see C1.3 Task 6');
+      if (this.state.kind !== 'idle') return; // guard against double-start
+      if (this.currentItem == null) return;
+
+      const ctx = deps.getAudioContext();
+      const stream = await deps.getMicStream();
+
+      // Dispatch ROUND_STARTED synthetically
+      const timbre = 'piano' as const;
+      const register = 'comfortable' as const;
+      void this.#dispatch({
+        type: 'ROUND_STARTED',
+        at_ms: Date.now(),
+        item: this.currentItem,
+        timbre,
+        register,
+      });
+
+      // Lazy-load the audio handles (web-platform modules)
+      const { playRound } = await import('@ear-training/web-platform/audio/player');
+      const { startPitchDetector } = await import('@ear-training/web-platform/pitch/pitch-detector');
+      const { startKeywordSpotter } = await import('@ear-training/web-platform/speech/keyword-spotter');
+      const { startAudioRecorder } = await import('@ear-training/web-platform/mic/recorder');
+      const { buildCadence } = await import('@ear-training/core/audio/cadence-structure');
+      const { buildTarget } = await import('@ear-training/core/audio/target-structure');
+      const { digitLabelToNumber } = await import('@ear-training/web-platform/speech/digit-label');
+
+      this.#pitchHandle = await startPitchDetector({ audioContext: ctx, micStream: stream });
+      this.#pitchHandle.subscribe((frame) => {
+        void this.#dispatch({ type: 'PITCH_FRAME', at_ms: Date.now(), hz: frame.hz, confidence: frame.confidence });
+      });
+
+      try {
+        this.#kwsHandle = await startKeywordSpotter({});
+        this.#kwsHandle.subscribe((frame) => {
+          if (frame.digit == null) return;
+          void this.#dispatch({
+            type: 'DIGIT_HEARD', at_ms: Date.now(),
+            digit: digitLabelToNumber(frame.digit),
+            confidence: frame.confidence,
+          });
+        });
+      } catch {
+        // KWS unavailable — degradation banner handled by shell store (Task in C1.4)
+      }
+
+      this.#recorderHandle = await startAudioRecorder({ audioContext: ctx, micStream: stream, maxDurationSec: 6 });
+
+      const cadence = buildCadence(this.currentItem.key);
+      const target = buildTarget(this.currentItem.key, this.currentItem.degree, register);
+      this.#playHandle = playRound({ timbreId: timbre, cadence, target, gapSec: 0.2 });
+
+      void this.#dispatch({ type: 'CADENCE_STARTED', at_ms: Date.now() });
+
+      // When target is about to start (Tone.js resolves targetStartAtAcTime)
+      void this.#playHandle.targetStartAtAcTime.then(() => {
+        void this.#dispatch({ type: 'TARGET_STARTED', at_ms: Date.now() });
+      });
+
+      // When playback completes, begin listening window
+      void this.#playHandle.done.then(() => {
+        void this.#dispatch({ type: 'PLAYBACK_DONE', at_ms: Date.now() });
+        this.#recorderHandle?.start();
+        this.#captureEndTimer = setTimeout(() => {
+          if (this.state.kind === 'listening') {
+            const thresholds = { minPitchConfidence: 0.5, minDigitConfidence: 0.5 };
+            const grade = gradeListeningState(this.state, this.currentItem!, thresholds);
+            void this.#dispatch({ type: 'CAPTURE_COMPLETE', at_ms: Date.now(), grade });
+          }
+        }, 5000) as unknown as number;
+      });
     }
 
     cancelRound(): void {
       if (this.#disposed) return;
-      this.#dispatch({ type: 'USER_CANCELED', at_ms: Date.now() });
+      void this.#dispatch({ type: 'USER_CANCELED', at_ms: Date.now() });
       this.#stopAudioHandles();
     }
 

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -98,4 +98,35 @@ describe('SessionController — capture-end + CAPTURE_COMPLETE', () => {
     ctrl._checkCaptureEnd();
     expect(ctrl.state.kind).toBe('listening');
   });
+
+  it('clears the capture-end timer when auto-advancing to graded', () => {
+    vi.useFakeTimers();
+    try {
+      const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+      const ctrl = createSessionController(makeDeps());
+
+      // Plant a fake timer id to simulate a pending capture-end setTimeout
+      const fakeTimerId = setTimeout(() => {}, 5000);
+      ctrl._forceTimer(fakeTimerId as unknown as number);
+
+      // Force into a listening state that will produce a passing grade
+      ctrl._forceState({
+        kind: 'listening',
+        item: baseItem, timbre: 'piano', register: 'comfortable',
+        targetStartedAt: 0,
+        frames: [{ at_ms: 100, hz: 392, confidence: 0.95 }],
+        digit: 5,
+        digitConfidence: 0.9,
+      } as never);
+
+      ctrl._checkCaptureEnd();
+
+      expect(ctrl.state.kind).toBe('graded');
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(fakeTimerId);
+    } finally {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    }
+  });
 });

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -65,3 +65,37 @@ describe('SessionController', () => {
     expect(() => ctrl.dispose()).not.toThrow();
   });
 });
+
+describe('SessionController — capture-end + CAPTURE_COMPLETE', () => {
+  it('auto-advances to graded when pitch + digit both confident (auto_advance_on_hit = true)', () => {
+    // This is a behavioral test; the mechanism is internal. We validate it
+    // by forcing a listening state with confident frames + digit and waiting
+    // for the state to flip to graded.
+    const ctrl = createSessionController(makeDeps());
+    ctrl._forceState({
+      kind: 'listening',
+      item: baseItem, timbre: 'piano', register: 'comfortable',
+      targetStartedAt: 0,
+      frames: [{ at_ms: 100, hz: 392, confidence: 0.95 }],
+      digit: 5,
+      digitConfidence: 0.9,
+    } as never);
+    // Manually invoke the capture-end check (Task 6 exposes _checkCaptureEnd test hook)
+    ctrl._checkCaptureEnd();
+    expect(ctrl.state.kind).toBe('graded');
+  });
+
+  it('does not auto-advance if confidence is below threshold', () => {
+    const ctrl = createSessionController(makeDeps());
+    ctrl._forceState({
+      kind: 'listening',
+      item: baseItem, timbre: 'piano', register: 'comfortable',
+      targetStartedAt: 0,
+      frames: [{ at_ms: 100, hz: 392, confidence: 0.3 }],
+      digit: 5,
+      digitConfidence: 0.3,
+    } as never);
+    ctrl._checkCaptureEnd();
+    expect(ctrl.state.kind).toBe('listening');
+  });
+});

--- a/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte
+++ b/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte
@@ -3,6 +3,7 @@
   import { getDeps } from '$lib/shell/deps';
   import { onDestroy, onMount } from 'svelte';
   import { resolve } from '$app/paths';
+  import { dev } from '$app/environment';
 
   let { data } = $props();
 
@@ -33,6 +34,11 @@
         return handle.stream;
       },
     });
+
+    if (dev || import.meta.env.MODE === 'test') {
+      // @ts-expect-error e2e hook — not present in production bundles
+      window.__sessionControllerForTest = controller;
+    }
   });
 
   onDestroy(() => controller?.dispose());


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Ctrl as SessionController
    participant Reducer as roundReducer
    participant Rec as AudioRecorder

    Ctrl->>Reducer: ROUND_STARTED
    Note over Reducer: idle → playing_cadence
    Ctrl->>Reducer: TARGET_STARTED
    Note over Reducer: playing_cadence → playing_target
    Ctrl->>Reducer: PLAYBACK_DONE
    Note over Reducer: playing_target → listening
    Rec-->>Ctrl: start() recording
    Note over Ctrl: _checkCaptureEnd() runs on every state update
    alt pitch + digit both confident (grade.outcome.pass)
        Ctrl->>Reducer: CAPTURE_COMPLETE (auto-advance)
    else 5s timeout
        Ctrl->>Reducer: CAPTURE_COMPLETE (timeout, may be fail)
    end
    Note over Reducer: listening → graded
    Ctrl->>Rec: stop() → AudioBuffer
    Note over Ctrl: capturedAudio = buf
```

## Summary

- Implements real `startRound()`: orchestrates cadence+target playback via `playRound`, starts pitch detector, KWS (with null-digit guard), and `AudioBufferRecorder` after `PLAYBACK_DONE`.
- Adds `_checkCaptureEnd()`: auto-advances to `graded` when both pitch and digit pass confidence thresholds; 5-second timeout fires `CAPTURE_COMPLETE` regardless (pass or fail grade).
- `#dispatch` is now async so the `listening → graded` transition can `await recorder.stop()` and attach the captured `AudioBuffer` to `controller.capturedAudio`; all callers use `void this.#dispatch(...)`.

## Screenshots

N/A — no visible UI change (no new Svelte component, no new CSS). The window hook addition to `+page.svelte` is dev/test-only and renders nothing.

## Test plan

- [x] `pnpm run typecheck && pnpm run test` — green (270 tests pass)
- [x] `pnpm run lint` — clean
- [x] 2 new unit tests added for `_checkCaptureEnd` (auto-advance on pass, no-advance below threshold)
- [x] `e2e/round-graded.spec.ts` added but marked `test.skip()` with TODO — FeedbackPanel + ReplayBar don't exist until Tasks 7–8
- [x] `window.__sessionControllerForTest` hook exposed in `dev` mode only (production bundle clean)

## Plan reference

Part of Plan C1.3, Task 6. See `docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md` (lines 1185–1510).

Design spec decision 3 (Option B — CAPTURE_COMPLETE with pre-computed outcome): `docs/specs/2026-04-16-plan-c1-ui-integration-design.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)