### PR TITLE
feat(exercise): variability picker wiring + next() implementation (Task 6.5)

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -1,7 +1,7 @@
 import { roundReducer } from '@ear-training/core/round/state';
 import type { RoundState } from '@ear-training/core/round/state';
 import type { RoundEvent } from '@ear-training/core/round/events';
-import type { Item, Session } from '@ear-training/core/types/domain';
+import type { Item, Session, Register } from '@ear-training/core/types/domain';
 import type {
   ItemsRepo, AttemptsRepo, SessionsRepo, SettingsRepo,
 } from '@ear-training/core/repos/interfaces';
@@ -10,7 +10,7 @@ import type { PitchDetectorHandle } from '@ear-training/web-platform/pitch/pitch
 import type { KeywordSpotterHandle } from '@ear-training/web-platform/speech/keyword-spotter';
 import type { RecorderHandle } from '@ear-training/web-platform/mic/recorder';
 import { gradeListeningState } from '@ear-training/core/round/grade-listening';
-import { pickTimbre, pickRegister, type VariabilityHistory } from '@ear-training/core/variability/pickers';
+import { pickTimbre, pickRegister, type VariabilityHistory, type TimbreId } from '@ear-training/core/variability/pickers';
 import { availableRegisters } from '@ear-training/core/scheduler/register-gating';
 
 export interface SessionControllerDeps {
@@ -42,6 +42,8 @@ export interface SessionController {
   _forceTimer(id: number): void;
   /** @internal — test hook */
   _checkCaptureEnd(): void;
+  /** @internal — test hook for variability picker integration */
+  _pickVariability(items: ReadonlyArray<Item>): { timbre: TimbreId; register: Register };
 }
 
 export function createSessionController(deps: SessionControllerDeps): SessionController {
@@ -113,11 +115,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       const stream = await deps.getMicStream();
 
       // Pick timbre and register via variability pickers (no monoculture)
-      const variabilitySettings = { lockedTimbre: null, lockedRegister: null };
       const allItems = await deps.itemsRepo.listAll();
-      const available = availableRegisters(allItems);
-      const timbre = pickTimbre(this.#rng, this.#history, variabilitySettings);
-      const register = pickRegister(this.#rng, this.#history, variabilitySettings, available);
+      const { timbre, register } = this._pickVariability(allItems);
 
       // Dispatch ROUND_STARTED synthetically
       void this.#dispatch({
@@ -127,9 +126,6 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
         timbre,
         register,
       });
-
-      // Persist history for next round (anti-repeat)
-      this.#history = { lastTimbre: timbre, lastRegister: register };
 
       // Lazy-load the audio handles (web-platform modules)
       const { playRound } = await import('@ear-training/web-platform/audio/player');
@@ -217,7 +213,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
 
       // More items due — advance.
       const dueNow = await deps.itemsRepo.findDue(Date.now());
-      const next = dueNow.find((i) => i.id !== sessionRow.focus_item_id) ?? dueNow[0] ?? null;
+      const justPlayed = this.currentItem?.id;
+      const next = dueNow.find((i) => i.id !== justPlayed) ?? dueNow[0] ?? null;
       if (next == null) {
         // Unusual: target_items says more to go but the queue is empty. Persist completion anyway.
         await deps.sessionsRepo.complete(sessionRow.id, {
@@ -260,6 +257,15 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       this.#pitchHandle = null;
       this.#kwsHandle = null;
       this.#recorderHandle = null;
+    }
+
+    _pickVariability(items: ReadonlyArray<Item>): { timbre: TimbreId; register: Register } {
+      const variabilitySettings = { lockedTimbre: null, lockedRegister: null };
+      const available = availableRegisters(items);
+      const timbre = pickTimbre(this.#rng, this.#history, variabilitySettings);
+      const register = pickRegister(this.#rng, this.#history, variabilitySettings, available);
+      this.#history = { lastTimbre: timbre, lastRegister: register };
+      return { timbre, register };
     }
 
     _forceState(state: RoundState): void {

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -10,6 +10,8 @@ import type { PitchDetectorHandle } from '@ear-training/web-platform/pitch/pitch
 import type { KeywordSpotterHandle } from '@ear-training/web-platform/speech/keyword-spotter';
 import type { RecorderHandle } from '@ear-training/web-platform/mic/recorder';
 import { gradeListeningState } from '@ear-training/core/round/grade-listening';
+import { pickTimbre, pickRegister, type VariabilityHistory } from '@ear-training/core/variability/pickers';
+import { availableRegisters } from '@ear-training/core/scheduler/register-gating';
 
 export interface SessionControllerDeps {
   session: Session;
@@ -20,6 +22,8 @@ export interface SessionControllerDeps {
   settingsRepo: SettingsRepo;
   getAudioContext: () => AudioContext;
   getMicStream: () => Promise<MediaStream>;
+  /** Optional rng for testability; defaults to Math.random. */
+  rng?: () => number;
 }
 
 export interface SessionController {
@@ -54,6 +58,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     #recorderHandle: RecorderHandle | null = null;
     #captureEndTimer: number | null = null;
     #disposed = false;
+    #history: VariabilityHistory = { lastTimbre: null, lastRegister: null };
+    #rng: () => number = deps.rng ?? Math.random;
 
     async #dispatch(event: RoundEvent): Promise<void> {
       const prev = this.state.kind;
@@ -106,9 +112,14 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       const ctx = deps.getAudioContext();
       const stream = await deps.getMicStream();
 
+      // Pick timbre and register via variability pickers (no monoculture)
+      const variabilitySettings = { lockedTimbre: null, lockedRegister: null };
+      const allItems = await deps.itemsRepo.listAll();
+      const available = availableRegisters(allItems);
+      const timbre = pickTimbre(this.#rng, this.#history, variabilitySettings);
+      const register = pickRegister(this.#rng, this.#history, variabilitySettings, available);
+
       // Dispatch ROUND_STARTED synthetically
-      const timbre = 'piano' as const;
-      const register = 'comfortable' as const;
       void this.#dispatch({
         type: 'ROUND_STARTED',
         at_ms: Date.now(),
@@ -116,6 +127,9 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
         timbre,
         register,
       });
+
+      // Persist history for next round (anti-repeat)
+      this.#history = { lastTimbre: timbre, lastRegister: register };
 
       // Lazy-load the audio handles (web-platform modules)
       const { playRound } = await import('@ear-training/web-platform/audio/player');
@@ -179,7 +193,52 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     }
 
     async next(): Promise<void> {
-      throw new Error('not implemented — see C1.3 Task 6');
+      if (this.#disposed) return;
+      if (this.state.kind !== 'graded') return; // guard: only callable post-grade
+
+      const sessionRow = this.session!;
+      const gradedState = this.state;
+      const completed = sessionRow.completed_items + 1;
+
+      if (completed >= sessionRow.target_items) {
+        // Session is full — complete it, do not start another round.
+        await deps.sessionsRepo.complete(sessionRow.id, {
+          ended_at: Date.now(),
+          completed_items: completed,
+          pitch_pass_count: sessionRow.pitch_pass_count + (gradedState.outcome.pitch ? 1 : 0),
+          label_pass_count: sessionRow.label_pass_count + (gradedState.outcome.label ? 1 : 0),
+          focus_item_id: sessionRow.focus_item_id,
+        });
+        this.session = { ...sessionRow, ended_at: Date.now(), completed_items: completed };
+        this.currentItem = null;
+        this.state = { kind: 'idle' };
+        return;
+      }
+
+      // More items due — advance.
+      const dueNow = await deps.itemsRepo.findDue(Date.now());
+      const next = dueNow.find((i) => i.id !== sessionRow.focus_item_id) ?? dueNow[0] ?? null;
+      if (next == null) {
+        // Unusual: target_items says more to go but the queue is empty. Persist completion anyway.
+        await deps.sessionsRepo.complete(sessionRow.id, {
+          ended_at: Date.now(),
+          completed_items: completed,
+          pitch_pass_count: sessionRow.pitch_pass_count + (gradedState.outcome.pitch ? 1 : 0),
+          label_pass_count: sessionRow.label_pass_count + (gradedState.outcome.label ? 1 : 0),
+          focus_item_id: sessionRow.focus_item_id,
+        });
+        this.session = { ...sessionRow, ended_at: Date.now(), completed_items: completed };
+        this.currentItem = null;
+        this.state = { kind: 'idle' };
+        return;
+      }
+
+      this.currentItem = next;
+      this.session = { ...sessionRow, completed_items: completed };
+      this.state = { kind: 'idle' };
+      // Reset captured/target audio for the next round.
+      this.capturedAudio = null;
+      this.targetAudio = null;
     }
 
     dispose(): void {

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -180,7 +180,10 @@ describe('SessionController — next()', () => {
   it('advances to idle with the next due item when more rounds remain', async () => {
     const nextItem: Item = { ...baseItem, id: '1-C-major', degree: 1 };
     const deps = makeDeps();
-    deps.itemsRepo.findDue = vi.fn(async () => [nextItem, baseItem]);
+    // Fixture order matters: baseItem (the just-played item) is first in the
+    // due queue so `dueNow[0]` would return it without the anti-repeat filter.
+    // The filter must skip baseItem and return nextItem.
+    deps.itemsRepo.findDue = vi.fn(async () => [baseItem, nextItem]);
     // Session with 1/30 items completed so far
     const session: Session = { ...baseSession, completed_items: 1, target_items: 30 };
     const ctrl = createSessionController({ ...deps, session, firstItem: baseItem });

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createSessionController } from './session-controller.svelte';
 import type { Item, Session } from '@ear-training/core/types/domain';
+import type { RoundState } from '@ear-training/core/round/state';
 
 const baseItem: Item = {
   id: '5-C-major',
@@ -128,5 +129,146 @@ describe('SessionController — capture-end + CAPTURE_COMPLETE', () => {
       vi.useRealTimers();
       vi.restoreAllMocks();
     }
+  });
+});
+
+// A graded state fixture used by variability and next() tests.
+const gradedState: RoundState = {
+  kind: 'graded',
+  item: baseItem,
+  timbre: 'piano',
+  register: 'comfortable',
+  outcome: { pitch: true, label: true, pass: true, at: 100 },
+  cents_off: 5,
+  sungBest: { at_ms: 100, hz: 392, confidence: 0.95 },
+  digitHeard: 5,
+  digitConfidence: 0.9,
+};
+
+describe('SessionController — variability picker wiring', () => {
+  it('avoids repeating the previous timbre across rounds', () => {
+    // With a deterministic rng biased to index 0, and lastTimbre = 'piano',
+    // pickTimbre should never return 'piano' (it is excluded from the pool).
+    // We seed rng = () => 0 which always picks pool[0]. The pool excludes
+    // lastTimbre, so two consecutive startRound() calls should differ.
+    //
+    // Because startRound() calls web-platform dynamic imports (which aren't
+    // available in vitest), we can only test the public surface via the
+    // dep-injectable rng. We verify that the controller accepts the rng dep
+    // and that pickTimbre/pickRegister are exercised by confirming the history
+    // field causes the timbre in ROUND_STARTED to avoid the previous value.
+    //
+    // Strategy: use rng = () => 0 (picks index 0 of the filtered pool).
+    // With lastTimbre = null → first available = 'piano' (TIMBRE_IDS[0]).
+    // With lastTimbre = 'piano' → pool excludes 'piano', so pool[0] = 'epiano'.
+    // We test this indirectly by checking that the controller does not throw
+    // and that it accepts the rng dep in SessionControllerDeps.
+    const rng = vi.fn(() => 0);
+    const deps = { ...makeDeps(), rng };
+    const ctrl = createSessionController(deps);
+    expect(ctrl.state.kind).toBe('idle');
+    // The dep is accepted and the controller is created without error.
+    // Full timbre-sequence verification is done in the variability/pickers unit tests.
+  });
+
+  it('passes listAll() result to availableRegisters for register gating', async () => {
+    // Items in 'reviewing'/'mastered' boxes unlock narrow + wide registers.
+    // With no advanced items, only 'comfortable' is available.
+    // We assert that listAll is called during startRound() — implicitly tested
+    // by verifying the mock is invoked.
+    //
+    // startRound() requires audio handles which aren't available in vitest;
+    // test calls are intentionally not awaited here — we only confirm the dep
+    // shape is wired.  The full integration path is covered by the e2e harness.
+    const deps = makeDeps();
+    const rng = () => 0;
+    const ctrl = createSessionController({ ...deps, rng });
+    expect(ctrl.state.kind).toBe('idle');
+    // listAll is present on itemsRepo mock with a valid return type.
+    expect(typeof deps.itemsRepo.listAll).toBe('function');
+  });
+});
+
+describe('SessionController — next()', () => {
+  it('is a no-op when not in graded state', async () => {
+    const ctrl = createSessionController(makeDeps());
+    // idle state — next() should return silently without throwing
+    await expect(ctrl.next()).resolves.toBeUndefined();
+    expect(ctrl.state.kind).toBe('idle');
+  });
+
+  it('advances to idle with the next due item when more rounds remain', async () => {
+    const nextItem: Item = { ...baseItem, id: '1-C-major', degree: 1 };
+    const deps = makeDeps();
+    deps.itemsRepo.findDue = vi.fn(async () => [nextItem, baseItem]);
+    // Session with 1/30 items completed so far
+    const session: Session = { ...baseSession, completed_items: 1, target_items: 30 };
+    const ctrl = createSessionController({ ...deps, session, firstItem: baseItem });
+
+    ctrl._forceState(gradedState);
+
+    await ctrl.next();
+
+    expect(ctrl.state.kind).toBe('idle');
+    expect(ctrl.currentItem?.id).toBe(nextItem.id);
+    expect(ctrl.session?.completed_items).toBe(2);
+    expect(ctrl.capturedAudio).toBeNull();
+    expect(ctrl.targetAudio).toBeNull();
+  });
+
+  it('completes the session when target_items is reached', async () => {
+    const deps = makeDeps();
+    // completed_items = 29, target_items = 30 → next() should complete
+    const session: Session = {
+      ...baseSession,
+      completed_items: 29,
+      target_items: 30,
+      pitch_pass_count: 15,
+      label_pass_count: 18,
+    };
+    const ctrl = createSessionController({ ...deps, session, firstItem: baseItem });
+
+    ctrl._forceState(gradedState);
+
+    await ctrl.next();
+
+    expect(ctrl.state.kind).toBe('idle');
+    expect(ctrl.currentItem).toBeNull();
+    expect(ctrl.session?.ended_at).not.toBeNull();
+    expect(ctrl.session?.completed_items).toBe(30);
+    expect(deps.sessionsRepo.complete).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({
+        completed_items: 30,
+        pitch_pass_count: 16, // 15 + 1 for the passing outcome
+        label_pass_count: 19, // 18 + 1
+      }),
+    );
+  });
+
+  it('completes the session when no due items remain despite target not reached', async () => {
+    const deps = makeDeps();
+    deps.itemsRepo.findDue = vi.fn(async () => []); // empty queue
+    const session: Session = { ...baseSession, completed_items: 5, target_items: 30 };
+    const ctrl = createSessionController({ ...deps, session, firstItem: baseItem });
+
+    ctrl._forceState(gradedState);
+
+    await ctrl.next();
+
+    expect(ctrl.state.kind).toBe('idle');
+    expect(ctrl.currentItem).toBeNull();
+    expect(ctrl.session?.ended_at).not.toBeNull();
+    expect(deps.sessionsRepo.complete).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing after dispose()', async () => {
+    const deps = makeDeps();
+    const ctrl = createSessionController(deps);
+    ctrl._forceState(gradedState);
+    ctrl.dispose();
+
+    await expect(ctrl.next()).resolves.toBeUndefined();
+    expect(deps.sessionsRepo.complete).not.toHaveBeenCalled();
   });
 });

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -147,45 +147,25 @@ const gradedState: RoundState = {
 
 describe('SessionController — variability picker wiring', () => {
   it('avoids repeating the previous timbre across rounds', () => {
-    // With a deterministic rng biased to index 0, and lastTimbre = 'piano',
-    // pickTimbre should never return 'piano' (it is excluded from the pool).
-    // We seed rng = () => 0 which always picks pool[0]. The pool excludes
-    // lastTimbre, so two consecutive startRound() calls should differ.
-    //
-    // Because startRound() calls web-platform dynamic imports (which aren't
-    // available in vitest), we can only test the public surface via the
-    // dep-injectable rng. We verify that the controller accepts the rng dep
-    // and that pickTimbre/pickRegister are exercised by confirming the history
-    // field causes the timbre in ROUND_STARTED to avoid the previous value.
-    //
-    // Strategy: use rng = () => 0 (picks index 0 of the filtered pool).
-    // With lastTimbre = null → first available = 'piano' (TIMBRE_IDS[0]).
-    // With lastTimbre = 'piano' → pool excludes 'piano', so pool[0] = 'epiano'.
-    // We test this indirectly by checking that the controller does not throw
-    // and that it accepts the rng dep in SessionControllerDeps.
-    const rng = vi.fn(() => 0);
-    const deps = { ...makeDeps(), rng };
-    const ctrl = createSessionController(deps);
-    expect(ctrl.state.kind).toBe('idle');
-    // The dep is accepted and the controller is created without error.
-    // Full timbre-sequence verification is done in the variability/pickers unit tests.
+    // rng = () => 0 always picks index 0 of the filtered pool.
+    // TIMBRE_IDS = ['piano', 'epiano', 'guitar', 'pad'].
+    // First call: lastTimbre = null → full pool → pool[0] = 'piano'.
+    // Second call: lastTimbre = 'piano' → pool excludes 'piano' → pool[0] = 'epiano'.
+    const rng = () => 0;
+    const ctrl = createSessionController({ ...makeDeps(), rng });
+    const first = ctrl._pickVariability([]);
+    const second = ctrl._pickVariability([]);
+    expect(first.timbre).toBe('piano');
+    expect(second.timbre).not.toBe(first.timbre);
   });
 
-  it('passes listAll() result to availableRegisters for register gating', async () => {
-    // Items in 'reviewing'/'mastered' boxes unlock narrow + wide registers.
-    // With no advanced items, only 'comfortable' is available.
-    // We assert that listAll is called during startRound() — implicitly tested
-    // by verifying the mock is invoked.
-    //
-    // startRound() requires audio handles which aren't available in vitest;
-    // test calls are intentionally not awaited here — we only confirm the dep
-    // shape is wired.  The full integration path is covered by the e2e harness.
-    const deps = makeDeps();
+  it('returns only comfortable register when no advanced items are present', () => {
+    // availableRegisters([]) = ['comfortable'] (narrow/wide need advanced items).
+    // So both calls return 'comfortable' regardless of anti-repeat (pool size = 1).
     const rng = () => 0;
-    const ctrl = createSessionController({ ...deps, rng });
-    expect(ctrl.state.kind).toBe('idle');
-    // listAll is present on itemsRepo mock with a valid return type.
-    expect(typeof deps.itemsRepo.listAll).toBe('function');
+    const ctrl = createSessionController({ ...makeDeps(), rng });
+    const first = ctrl._pickVariability([]);
+    expect(first.register).toBe('comfortable');
   });
 });
 

--- a/docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md
+++ b/docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md
@@ -1530,47 +1530,34 @@ Append to `session-controller.test.ts`:
 
 ```typescript
 describe('SessionController — variability picker wiring', () => {
-  it('avoids repeating the previous timbre across rounds', async () => {
-    // Seed rng = () => 0 (always picks index 0 of the filtered pool).
-    // With lastTimbre = 'piano', pool excludes 'piano', so pool[0] = 'epiano'.
-    // We verify the controller accepts the rng dep without error.
-    const rng = vi.fn(() => 0);
-    const deps = { ...makeDeps(), rng };
-    const ctrl = createSessionController(deps);
-    expect(ctrl.state.kind).toBe('idle');
+  it('avoids repeating the previous timbre across rounds', () => {
+    // rng = () => 0 always picks index 0 of the filtered pool.
+    // TIMBRE_IDS = ['piano', 'epiano', 'guitar', 'pad'].
+    // First call: lastTimbre = null → full pool → pool[0] = 'piano'.
+    // Second call: lastTimbre = 'piano' → pool excludes 'piano' → pool[0] = 'epiano'.
+    const rng = () => 0;
+    const ctrl = createSessionController({ ...makeDeps(), rng });
+    const first = ctrl._pickVariability([]);
+    const second = ctrl._pickVariability([]);
+    expect(first.timbre).toBe('piano');
+    expect(second.timbre).not.toBe(first.timbre);
   });
 
-  it('passes listAll() result to availableRegisters for register gating', async () => {
-    // listAll must exist on the itemsRepo dep and be callable.
-    const deps = makeDeps();
-    const ctrl = createSessionController({ ...deps, rng: () => 0 });
-    expect(ctrl.state.kind).toBe('idle');
-    expect(typeof deps.itemsRepo.listAll).toBe('function');
-  });
-});
-
-describe('SessionController — next()', () => {
-  it('is a no-op when not in graded state', async () => {
-    const ctrl = createSessionController(makeDeps());
-    await expect(ctrl.next()).resolves.toBeUndefined();
-    expect(ctrl.state.kind).toBe('idle');
-  });
-
-  it('advances to idle with the next due item when more rounds remain', async () => {
-    // Given a graded state and more items due, next() sets state to idle
-    // with the next item and increments completed_items.
-    // ...
-  });
-
-  it('completes the session when target_items is reached', async () => {
-    // Given completed_items === target_items - 1 (about to hit target),
-    // next() calls sessionsRepo.complete and sets ended_at.
-    // ...
+  it('returns only comfortable register when no advanced items are present', () => {
+    // availableRegisters([]) = ['comfortable']; narrow/wide need advanced items.
+    const rng = () => 0;
+    const ctrl = createSessionController({ ...makeDeps(), rng });
+    const first = ctrl._pickVariability([]);
+    expect(first.register).toBe('comfortable');
   });
 });
 ```
 
-(The subagent writes the full test bodies using the existing `makeDeps()` / `_forceState()` scaffolding already in the file.)
+`_pickVariability` is a `@internal` test hook on the `SessionController` interface (added in Step 3).
+It inlines the picker logic and mutates `#history`, so calling it twice with `rng = () => 0`
+verifies the anti-repeat filter without invoking `startRound()` or any dynamic imports.
+
+(Full test bodies for `next()` use the existing `makeDeps()` / `_forceState()` scaffolding.)
 
 - [ ] **Step 3: Wire `VariabilityHistory` into the controller**
 
@@ -1625,7 +1612,8 @@ async next(): Promise<void> {
 
   // More items due — advance.
   const dueNow = await deps.itemsRepo.findDue(Date.now());
-  const next = dueNow.find((i) => i.id !== sessionRow.focus_item_id) ?? dueNow[0] ?? null;
+  const justPlayed = this.currentItem?.id;
+  const next = dueNow.find((i) => i.id !== justPlayed) ?? dueNow[0] ?? null;
   if (next == null) {
     // Unusual: target_items says more to go but the queue is empty. Persist completion anyway.
     await deps.sessionsRepo.complete(sessionRow.id, {
@@ -1726,8 +1714,9 @@ export function tooltipFor(degree: Degree, quality: 'major' | 'minor'): string {
 Create `apps/ear-training-station/src/lib/exercises/scale-degree/internal/FeedbackPanel.test.ts`:
 
 ```typescript
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import FeedbackPanel from './FeedbackPanel.svelte';
 
 const graded = {
@@ -1768,6 +1757,13 @@ describe('FeedbackPanel', () => {
       showTooltip: false,
     });
     expect(screen.getByText(/you sang 5 but said 4/i)).toBeInTheDocument();
+  });
+
+  it('clicking Next round button fires onNext', async () => {
+    const onNext = vi.fn();
+    render(FeedbackPanel, { state: graded, showTooltip: false, onNext });
+    await userEvent.click(screen.getByRole('button', { name: /next round/i }));
+    expect(onNext).toHaveBeenCalledOnce();
   });
 });
 ```
@@ -1812,9 +1808,11 @@ Create `apps/ear-training-station/src/lib/exercises/scale-degree/internal/Feedba
   let {
     state,
     showTooltip,
+    onNext,
   }: {
     state: Extract<RoundState, { kind: 'graded' }>;
     showTooltip: boolean;
+    onNext?: () => void;
   } = $props();
 
   const targetDegree = state.item.degree;
@@ -1907,7 +1905,11 @@ Modify the `{#if}` block in the route page:
 {#if data.session.ended_at == null && controller}
   <ActiveRound {controller} />
   {#if controller.state.kind === 'graded'}
-    <FeedbackPanel state={controller.state} showTooltip={$settings.function_tooltip} />
+    <FeedbackPanel
+      state={controller.state}
+      showTooltip={$settings.function_tooltip}
+      onNext={() => { void controller.next().then(() => controller.startRound()); }}
+    />
     <!-- ReplayBar mounts in Task 8 -->
   {/if}
 {:else if data.session.ended_at != null}

--- a/docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md
+++ b/docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md
@@ -1509,6 +1509,168 @@ Part of Plan C1.3.
 
 ---
 
+### Task 6.5: Variability picker wiring + `next()` implementation
+
+Addendum to Plan C1.3 (added post-PR #84). Task 6 left two spec-critical pieces unwired: `startRound()` still hardcodes `timbre: 'piano'` and `register: 'comfortable'`, and `next()` still throws. Both must land before Task 7 (FeedbackPanel) ships a "Next round" button.
+
+**Files:**
+- Modify: `apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts`
+- Modify: `apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts`
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout main && git pull
+git checkout -b c1-3/task6-5-variability-next
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Append to `session-controller.test.ts`:
+
+```typescript
+describe('SessionController — variability picker wiring', () => {
+  it('avoids repeating the previous timbre across rounds', async () => {
+    // Seed rng = () => 0 (always picks index 0 of the filtered pool).
+    // With lastTimbre = 'piano', pool excludes 'piano', so pool[0] = 'epiano'.
+    // We verify the controller accepts the rng dep without error.
+    const rng = vi.fn(() => 0);
+    const deps = { ...makeDeps(), rng };
+    const ctrl = createSessionController(deps);
+    expect(ctrl.state.kind).toBe('idle');
+  });
+
+  it('passes listAll() result to availableRegisters for register gating', async () => {
+    // listAll must exist on the itemsRepo dep and be callable.
+    const deps = makeDeps();
+    const ctrl = createSessionController({ ...deps, rng: () => 0 });
+    expect(ctrl.state.kind).toBe('idle');
+    expect(typeof deps.itemsRepo.listAll).toBe('function');
+  });
+});
+
+describe('SessionController — next()', () => {
+  it('is a no-op when not in graded state', async () => {
+    const ctrl = createSessionController(makeDeps());
+    await expect(ctrl.next()).resolves.toBeUndefined();
+    expect(ctrl.state.kind).toBe('idle');
+  });
+
+  it('advances to idle with the next due item when more rounds remain', async () => {
+    // Given a graded state and more items due, next() sets state to idle
+    // with the next item and increments completed_items.
+    // ...
+  });
+
+  it('completes the session when target_items is reached', async () => {
+    // Given completed_items === target_items - 1 (about to hit target),
+    // next() calls sessionsRepo.complete and sets ended_at.
+    // ...
+  });
+});
+```
+
+(The subagent writes the full test bodies using the existing `makeDeps()` / `_forceState()` scaffolding already in the file.)
+
+- [ ] **Step 3: Wire `VariabilityHistory` into the controller**
+
+In `session-controller.svelte.ts`:
+
+- Add `rng?: () => number` to `SessionControllerDeps` (defaults to `Math.random`).
+- Add a private `#history: VariabilityHistory = { lastTimbre: null, lastRegister: null }` field.
+- Add a private `#rng: () => number = deps.rng ?? Math.random` field.
+- At the top of `startRound()`, before the existing `ROUND_STARTED` dispatch, compute:
+  - `const variabilitySettings = { lockedTimbre: null, lockedRegister: null }` (Settings don't currently carry these; wire a real bridge when they do)
+  - `const allItems = await deps.itemsRepo.listAll()` for the registers gate
+  - `const available = availableRegisters(allItems)`
+  - `const timbre = pickTimbre(this.#rng, this.#history, variabilitySettings)`
+  - `const register = pickRegister(this.#rng, this.#history, variabilitySettings, available)`
+- Replace the hardcoded literals in the `ROUND_STARTED` dispatch and `playRound` call with those values.
+- After dispatch, update history: `this.#history = { lastTimbre: timbre, lastRegister: register }`.
+
+Imports to add:
+
+```typescript
+import { pickTimbre, pickRegister, type VariabilityHistory } from '@ear-training/core/variability/pickers';
+import { availableRegisters } from '@ear-training/core/scheduler/register-gating';
+```
+
+- [ ] **Step 4: Implement `next()`**
+
+Replace the stub:
+
+```typescript
+async next(): Promise<void> {
+  if (this.#disposed) return;
+  if (this.state.kind !== 'graded') return; // guard: only callable post-grade
+
+  const sessionRow = this.session!;
+  const gradedState = this.state;
+  const completed = sessionRow.completed_items + 1;
+
+  if (completed >= sessionRow.target_items) {
+    // Session is full — complete it, do not start another round.
+    await deps.sessionsRepo.complete(sessionRow.id, {
+      ended_at: Date.now(),
+      completed_items: completed,
+      pitch_pass_count: sessionRow.pitch_pass_count + (gradedState.outcome.pitch ? 1 : 0),
+      label_pass_count: sessionRow.label_pass_count + (gradedState.outcome.label ? 1 : 0),
+      focus_item_id: sessionRow.focus_item_id,
+    });
+    this.session = { ...sessionRow, ended_at: Date.now(), completed_items: completed };
+    this.currentItem = null;
+    this.state = { kind: 'idle' };
+    return;
+  }
+
+  // More items due — advance.
+  const dueNow = await deps.itemsRepo.findDue(Date.now());
+  const next = dueNow.find((i) => i.id !== sessionRow.focus_item_id) ?? dueNow[0] ?? null;
+  if (next == null) {
+    // Unusual: target_items says more to go but the queue is empty. Persist completion anyway.
+    await deps.sessionsRepo.complete(sessionRow.id, {
+      ended_at: Date.now(),
+      completed_items: completed,
+      pitch_pass_count: sessionRow.pitch_pass_count + (gradedState.outcome.pitch ? 1 : 0),
+      label_pass_count: sessionRow.label_pass_count + (gradedState.outcome.label ? 1 : 0),
+      focus_item_id: sessionRow.focus_item_id,
+    });
+    this.session = { ...sessionRow, ended_at: Date.now(), completed_items: completed };
+    this.currentItem = null;
+    this.state = { kind: 'idle' };
+    return;
+  }
+
+  this.currentItem = next;
+  this.session = { ...sessionRow, completed_items: completed };
+  this.state = { kind: 'idle' };
+  // Reset capturedAudio / targetAudio for the next round.
+  this.capturedAudio = null;
+  this.targetAudio = null;
+}
+```
+
+(Deliberately does NOT auto-call `startRound()`. The UI decides: FeedbackPanel's "Next round" button calls `controller.next()` then `controller.startRound()`.)
+
+- [ ] **Step 5: Run tests — expect pass**
+
+```bash
+pnpm --filter ear-training-station test session-controller
+```
+
+- [ ] **Step 6: Full suite + lint + typecheck**
+
+```bash
+pnpm run typecheck && pnpm run test && pnpm run lint
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Commit + PR**
+(standard PR flow; diagrams section can note "N/A — no UI change, controller-internal wiring"; include link to the design spec's decision 3 + "Variability by default" non-negotiable)
+
+---
+
 ### Task 7: `FeedbackPanel.svelte` (+ `PitchNullHint`)
 
 Renders the F2 feedback panel from the spec: pitch ✓/✗ with cents, label ✓/✗ with spoken digit, plain-English explanation, optional function tooltip, and `PitchNullHint` after 3+ consecutive nulls.


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant UI as FeedbackPanel (Task 7)
    participant C as SessionController
    participant SR as sessionsRepo
    participant IR as itemsRepo

    Note over C: state = graded
    UI->>C: next()
    C->>C: completed = session.completed_items + 1

    alt completed >= target_items
        C->>SR: complete(id, { ended_at, completed_items, ... })
        C->>C: state = idle, currentItem = null, session.ended_at set
    else dueNow is empty
        C->>IR: findDue(now)
        IR-->>C: []
        C->>SR: complete(id, { ended_at, completed_items, ... })
        C->>C: state = idle, currentItem = null
    else more items available
        C->>IR: findDue(now)
        IR-->>C: [nextItem, ...]
        C->>C: currentItem = nextItem, state = idle, completed_items++
    end

    Note over C: capturedAudio = null, targetAudio = null
```

Variability wiring (per round):

```mermaid
sequenceDiagram
    participant C as SessionController
    participant IR as itemsRepo
    participant P as pickers

    C->>IR: listAll()
    IR-->>C: items[]
    C->>P: availableRegisters(items)
    P-->>C: available[]
    C->>P: pickTimbre(rng, history, settings)
    P-->>C: timbre (≠ lastTimbre)
    C->>P: pickRegister(rng, history, settings, available)
    P-->>C: register (≠ lastRegister)
    C->>C: #history = { lastTimbre: timbre, lastRegister: register }
```

## Summary

- **S1 — variability pickers wired**: `startRound()` no longer hardcodes `timbre: 'piano'` / `register: 'comfortable'`. Uses `pickTimbre` + `pickRegister` with per-session `VariabilityHistory` (persists across rounds, resets on controller creation). `availableRegisters(listAll())` feeds the register gate. `lockedTimbre`/`lockedRegister` are `null` until Settings carries them.
- **S2 — `next()` implemented**: replaces the `throw new Error('not implemented')` stub. Increments `completed_items`, calls `sessionsRepo.complete` when session is full or queue is empty, otherwise advances `currentItem` to the next due item and resets state to `idle`. Does NOT auto-call `startRound()` — that is the UI's responsibility (FeedbackPanel's "Next round" button in Task 7).
- **rng injection**: `SessionControllerDeps.rng?: () => number` added for deterministic tests; defaults to `Math.random`.
- **Plan addendum**: Task 6.5 inserted into `docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md` between Task 6 and Task 7.

Spec reference: "Variability by default. Timbre monoculture is the incumbents' biggest failure." ([spec line 31](docs/specs/2026-04-14-ear-training-mvp-design.md))

## Test plan

- [x] `pnpm --filter ear-training-station test session-controller` — 14 tests pass (+7 new: variability wiring × 2, next() × 5)
- [x] `pnpm run test` — 278 tests pass across all packages (+7)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [ ] Screenshots: N/A — controller-internal wiring, no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)