### PR TITLE
feat(exercise): FeedbackPanel + PitchNullHint (Task 7)

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/index.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/index.ts
@@ -15,3 +15,4 @@ export const manifest: ExerciseManifest = {
 export { createSessionController } from './internal/session-controller.svelte';
 export type { SessionController, SessionControllerDeps } from './internal/session-controller.svelte';
 export { default as ActiveRound } from './internal/ActiveRound.svelte';
+export { default as FeedbackPanel } from './internal/FeedbackPanel.svelte';

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/FeedbackPanel.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/FeedbackPanel.svelte
@@ -19,16 +19,19 @@
 
   function explanation(): string {
     const { outcome, digitHeard, cents_off } = state;
+    const centsLabel = cents_off != null ? Math.round(cents_off) : null;
+    const direction = centsLabel != null ? (centsLabel >= 0 ? 'sharp' : 'flat') : null;
+    const centsText = centsLabel != null ? `${Math.abs(centsLabel)}¢ ${direction}` : 'unclear';
     if (outcome.pass) {
       return `Nice. You hit ${targetDegree} — ${targetKey.tonic}${targetKey.quality === 'minor' ? ' minor' : ''}.`;
     }
     if (!outcome.pitch && outcome.label) {
-      return `You said ${targetDegree} but your pitch was ${cents_off ?? '?'}¢ off.`;
+      return `You said ${targetDegree} but your pitch was ${centsText}.`;
     }
     if (outcome.pitch && !outcome.label) {
       return `You sang ${targetDegree} but said ${digitHeard ?? '—'}.`;
     }
-    return `Target was ${targetDegree}. You sang ${cents_off != null ? `${cents_off}¢ off` : 'unclear'} and said ${digitHeard ?? '—'}.`;
+    return `Target was ${targetDegree}. You sang ${centsText} and said ${digitHeard ?? '—'}.`;
   }
 </script>
 

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/FeedbackPanel.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/FeedbackPanel.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import type { RoundState } from '@ear-training/core/round/state';
+  import { tooltipFor } from './function-tooltips';
+  import { consecutiveNullCount } from '$lib/shell/stores';
+  import PitchNullHint from './PitchNullHint.svelte';
+
+  let {
+    state,
+    showTooltip,
+    onNext,
+  }: {
+    state: Extract<RoundState, { kind: 'graded' }>;
+    showTooltip: boolean;
+    onNext?: () => void;
+  } = $props();
+
+  const targetDegree = $derived(state.item.degree);
+  const targetKey = $derived(state.item.key);
+
+  function explanation(): string {
+    const { outcome, digitHeard, cents_off } = state;
+    if (outcome.pass) {
+      return `Nice. You hit ${targetDegree} — ${targetKey.tonic}${targetKey.quality === 'minor' ? ' minor' : ''}.`;
+    }
+    if (!outcome.pitch && outcome.label) {
+      return `You said ${targetDegree} but your pitch was ${cents_off ?? '?'}¢ off.`;
+    }
+    if (outcome.pitch && !outcome.label) {
+      return `You sang ${targetDegree} but said ${digitHeard ?? '—'}.`;
+    }
+    return `Target was ${targetDegree}. You sang ${cents_off != null ? `${cents_off}¢ off` : 'unclear'} and said ${digitHeard ?? '—'}.`;
+  }
+</script>
+
+<section class="feedback-panel">
+  <div class="result-grid">
+    <div class="cell">
+      <div class="badge" class:pass={state.outcome.pitch} class:fail={!state.outcome.pitch}>
+        {state.outcome.pitch ? '✓' : '✗'}
+      </div>
+      <div class="detail">
+        <div class="label">Pitch</div>
+        <div class="value">{state.cents_off != null ? `${Math.round(state.cents_off)}¢` : '—'}</div>
+      </div>
+    </div>
+    <div class="cell">
+      <div class="badge" class:pass={state.outcome.label} class:fail={!state.outcome.label}>
+        {state.outcome.label ? '✓' : '✗'}
+      </div>
+      <div class="detail">
+        <div class="label">Label</div>
+        <div class="value">{state.digitHeard ?? '—'}</div>
+      </div>
+    </div>
+  </div>
+
+  <p class="explanation">{explanation()}</p>
+
+  {#if showTooltip}
+    <p class="tooltip">{tooltipFor(targetDegree, targetKey.quality)}</p>
+  {/if}
+
+  {#if $consecutiveNullCount >= 3}
+    <PitchNullHint />
+  {/if}
+
+  <button type="button" class="next-btn" onclick={() => onNext?.()}>Next round</button>
+</section>
+
+<style>
+  .feedback-panel {
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    margin-top: 12px;
+  }
+  .result-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+  .cell {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .badge {
+    width: 22px; height: 22px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-weight: 700; font-size: 14px;
+  }
+  .pass { background: var(--green); color: #0a0a0a; }
+  .fail { background: var(--red); color: #0a0a0a; }
+  .label { font-size: 9px; text-transform: uppercase; color: var(--muted); }
+  .value { font-variant-numeric: tabular-nums; font-size: 16px; color: var(--text); }
+  .explanation { font-size: 11px; color: var(--muted); margin: 12px 0 0; }
+  .tooltip { font-size: 11px; color: var(--amber); margin: 8px 0 0; padding-top: 8px; border-top: 1px dashed var(--border); }
+  .next-btn {
+    margin-top: 12px;
+    padding: 8px 18px;
+    border-radius: 6px;
+    border: 1px solid var(--cyan);
+    background: transparent;
+    color: var(--cyan);
+    font-size: 12px;
+    cursor: pointer;
+  }
+</style>

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/FeedbackPanel.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/FeedbackPanel.test.ts
@@ -19,7 +19,7 @@ describe('FeedbackPanel', () => {
   it('shows pass badges and cents value on a passing attempt', () => {
     render(FeedbackPanel, { state: graded, showTooltip: true });
     expect(screen.getAllByText(/✓/).length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText(/3/)).toBeInTheDocument(); // cents
+    expect(screen.getByText(/3¢/)).toBeInTheDocument(); // cents badge cell
   });
 
   it('shows fail badges when pitch fails', () => {
@@ -48,5 +48,29 @@ describe('FeedbackPanel', () => {
     render(FeedbackPanel, { state: graded, showTooltip: false, onNext });
     await userEvent.click(screen.getByRole('button', { name: /next round/i }));
     expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it('explanation uses rounded cents with sharp direction when pitch fails (positive cents_off)', () => {
+    render(FeedbackPanel, {
+      state: { ...graded, outcome: { pitch: false, label: true, pass: false, at: 0 }, cents_off: 12.7 },
+      showTooltip: false,
+    });
+    expect(screen.getByText(/13¢ sharp/i)).toBeInTheDocument();
+  });
+
+  it('explanation uses rounded cents with flat direction when cents_off is negative', () => {
+    render(FeedbackPanel, {
+      state: { ...graded, outcome: { pitch: false, label: true, pass: false, at: 0 }, cents_off: -23 },
+      showTooltip: false,
+    });
+    expect(screen.getByText(/23¢ flat/i)).toBeInTheDocument();
+  });
+
+  it('explanation uses "unclear" when cents_off is null', () => {
+    render(FeedbackPanel, {
+      state: { ...graded, outcome: { pitch: false, label: false, pass: false, at: 0 }, cents_off: null },
+      showTooltip: false,
+    });
+    expect(screen.getByText(/unclear/i)).toBeInTheDocument();
   });
 });

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/FeedbackPanel.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/FeedbackPanel.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import FeedbackPanel from './FeedbackPanel.svelte';
+
+const graded = {
+  kind: 'graded' as const,
+  item: { id: '5-C-major', degree: 5 as const, key: { tonic: 'C' as const, quality: 'major' as const }, box: 'new' as const, accuracy: { pitch: 0, label: 0 }, recent: [], attempts: 0, consecutive_passes: 0, last_seen_at: null, due_at: 0, created_at: 0 },
+  timbre: 'piano' as const,
+  register: 'comfortable' as const,
+  outcome: { pitch: true, label: true, pass: true, at: 0 },
+  cents_off: 3,
+  sungBest: { at_ms: 100, hz: 392, confidence: 0.95 },
+  digitHeard: 5 as const,
+  digitConfidence: 0.9,
+};
+
+describe('FeedbackPanel', () => {
+  it('shows pass badges and cents value on a passing attempt', () => {
+    render(FeedbackPanel, { state: graded, showTooltip: true });
+    expect(screen.getAllByText(/✓/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/3/)).toBeInTheDocument(); // cents
+  });
+
+  it('shows fail badges when pitch fails', () => {
+    render(FeedbackPanel, {
+      state: { ...graded, outcome: { pitch: false, label: true, pass: false, at: 0 }, cents_off: 70 },
+      showTooltip: true,
+    });
+    expect(screen.getAllByText(/✗/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('hides tooltip when showTooltip = false', () => {
+    render(FeedbackPanel, { state: graded, showTooltip: false });
+    expect(screen.queryByText(/resolves/i)).not.toBeInTheDocument();
+  });
+
+  it('shows plain-English explanation', () => {
+    render(FeedbackPanel, {
+      state: { ...graded, outcome: { pitch: true, label: false, pass: false, at: 0 }, digitHeard: 4 },
+      showTooltip: false,
+    });
+    expect(screen.getByText(/you sang 5 but said 4/i)).toBeInTheDocument();
+  });
+
+  it('clicking Next round button fires onNext', async () => {
+    const onNext = vi.fn();
+    render(FeedbackPanel, { state: graded, showTooltip: false, onNext });
+    await userEvent.click(screen.getByRole('button', { name: /next round/i }));
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchNullHint.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/PitchNullHint.svelte
@@ -1,0 +1,18 @@
+<div class="hint">
+  <p>
+    We're not hearing anything clearly. Check your mic input level and
+    try singing a steady, sustained note.
+  </p>
+</div>
+
+<style>
+  .hint {
+    padding: 10px 12px;
+    background: #2a1e05;
+    border: 1px solid var(--amber);
+    border-radius: 6px;
+    color: var(--amber);
+    font-size: 11px;
+    margin-top: 12px;
+  }
+</style>

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/function-tooltips.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/function-tooltips.ts
@@ -1,0 +1,25 @@
+import type { Degree } from '@ear-training/core/types/music';
+
+const MAJOR: Record<Degree, string> = {
+  1: 'The 1 is home — the tonic. Everything resolves here.',
+  2: 'The 2 is a subtle tension, pulling up to the 3 or down to the 1.',
+  3: 'The 3 is the bright, happy note of the key.',
+  4: 'The 4 wants to resolve down to the 3.',
+  5: 'The 5 is the brightest tension; it pulls strongly back to the 1.',
+  6: 'The 6 is a rich, melodic note that often wants to fall to the 5.',
+  7: 'The 7 is the leading tone — it craves the 1.',
+};
+
+const MINOR: Record<Degree, string> = {
+  1: 'The 1 is home in the minor key.',
+  2: 'The 2 in minor has a distinctive tension.',
+  3: 'The flat 3 gives the minor its melancholic color.',
+  4: 'The 4 is a stable subdominant.',
+  5: 'The 5 wants to resolve to the 1.',
+  6: 'The flat 6 adds drama.',
+  7: 'The 7 (usually the leading tone in harmonic minor) wants to resolve up.',
+};
+
+export function tooltipFor(degree: Degree, quality: 'major' | 'minor'): string {
+  return (quality === 'major' ? MAJOR : MINOR)[degree];
+}

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -12,6 +12,7 @@ import type { RecorderHandle } from '@ear-training/web-platform/mic/recorder';
 import { gradeListeningState } from '@ear-training/core/round/grade-listening';
 import { pickTimbre, pickRegister, type VariabilityHistory, type TimbreId } from '@ear-training/core/variability/pickers';
 import { availableRegisters } from '@ear-training/core/scheduler/register-gating';
+import { consecutiveNullCount } from '$lib/shell/stores';
 
 export interface SessionControllerDeps {
   session: Session;
@@ -44,6 +45,8 @@ export interface SessionController {
   _checkCaptureEnd(): void;
   /** @internal — test hook for variability picker integration */
   _pickVariability(items: ReadonlyArray<Item>): { timbre: TimbreId; register: Register };
+  /** @internal — test hook: simulate a pitch frame arriving from the detector */
+  _onPitchFrame(frame: { hz: number; confidence: number }): void;
 }
 
 export function createSessionController(deps: SessionControllerDeps): SessionController {
@@ -138,7 +141,7 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
 
       this.#pitchHandle = await startPitchDetector({ audioContext: ctx, micStream: stream });
       this.#pitchHandle.subscribe((frame) => {
-        void this.#dispatch({ type: 'PITCH_FRAME', at_ms: Date.now(), hz: frame.hz, confidence: frame.confidence });
+        this._onPitchFrame(frame);
       });
 
       try {
@@ -191,6 +194,9 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     async next(): Promise<void> {
       if (this.#disposed) return;
       if (this.state.kind !== 'graded') return; // guard: only callable post-grade
+
+      // Reset mic-check counter so the new round starts clean.
+      consecutiveNullCount.set(0);
 
       const sessionRow = this.session!;
       const gradedState = this.state;
@@ -266,6 +272,17 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       const register = pickRegister(this.#rng, this.#history, variabilitySettings, available);
       this.#history = { lastTimbre: timbre, lastRegister: register };
       return { timbre, register };
+    }
+
+    _onPitchFrame(frame: { hz: number; confidence: number }): void {
+      // Update the mic-check hint store (consecutiveNullCount).
+      // A "null" frame is one with no signal (hz <= 0) or low confidence (< 0.5).
+      if (frame.hz <= 0 || frame.confidence < 0.5) {
+        consecutiveNullCount.update((n) => n + 1);
+      } else {
+        consecutiveNullCount.set(0);
+      }
+      void this.#dispatch({ type: 'PITCH_FRAME', at_ms: Date.now(), hz: frame.hz, confidence: frame.confidence });
     }
 
     _forceState(state: RoundState): void {

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
 import { createSessionController } from './session-controller.svelte';
 import type { Item, Session } from '@ear-training/core/types/domain';
 import type { RoundState } from '@ear-training/core/round/state';
+import { consecutiveNullCount } from '$lib/shell/stores';
 
 const baseItem: Item = {
   id: '5-C-major',
@@ -253,5 +255,36 @@ describe('SessionController — next()', () => {
 
     await expect(ctrl.next()).resolves.toBeUndefined();
     expect(deps.sessionsRepo.complete).not.toHaveBeenCalled();
+  });
+});
+
+describe('SessionController — consecutiveNullCount store', () => {
+  beforeEach(() => {
+    // Reset store between tests to avoid leakage.
+    consecutiveNullCount.set(0);
+  });
+
+  it('increments consecutiveNullCount when a low-confidence frame arrives', () => {
+    const ctrl = createSessionController(makeDeps());
+    ctrl._onPitchFrame({ hz: 0, confidence: 0 });
+    expect(get(consecutiveNullCount)).toBe(1);
+    ctrl._onPitchFrame({ hz: 440, confidence: 0.3 });
+    expect(get(consecutiveNullCount)).toBe(2);
+  });
+
+  it('resets consecutiveNullCount to 0 when a high-confidence frame arrives', () => {
+    const ctrl = createSessionController(makeDeps());
+    // Seed the store to a non-zero value.
+    consecutiveNullCount.set(5);
+    ctrl._onPitchFrame({ hz: 440, confidence: 0.95 });
+    expect(get(consecutiveNullCount)).toBe(0);
+  });
+
+  it('resets consecutiveNullCount to 0 when next() is called', async () => {
+    const ctrl = createSessionController(makeDeps());
+    consecutiveNullCount.set(4);
+    ctrl._forceState(gradedState);
+    await ctrl.next();
+    expect(get(consecutiveNullCount)).toBe(0);
   });
 });

--- a/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte
+++ b/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { createSessionController, ActiveRound } from '$lib/exercises/scale-degree';
+  import { createSessionController, ActiveRound, FeedbackPanel } from '$lib/exercises/scale-degree';
   import { getDeps } from '$lib/shell/deps';
+  import { settings } from '$lib/shell/stores';
   import { onDestroy, onMount } from 'svelte';
   import { resolve } from '$app/paths';
   import { dev } from '$app/environment';
@@ -46,7 +47,14 @@
 
 {#if data.session.ended_at == null && controller}
   <ActiveRound {controller} />
-  <!-- FeedbackPanel (Task 7) + ReplayBar (Task 8) mount here when state === 'graded' -->
+  {#if controller.state.kind === 'graded'}
+    <FeedbackPanel
+      state={controller.state}
+      showTooltip={$settings.function_tooltip}
+      onNext={() => { const c = controller; if (c) void c.next().then(() => c.startRound()); }}
+    />
+    <!-- ReplayBar mounts in Task 8 -->
+  {/if}
 {:else if data.session.ended_at == null && noItemsDue}
   <p>No items are due right now. <a href={resolve('/')}>Return to dashboard</a></p>
 {:else if data.session.ended_at == null}


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    [*] --> graded : CAPTURE_COMPLETE
    graded --> FeedbackPanel : controller.state.kind === 'graded'
    FeedbackPanel --> onNext_click : user clicks "Next round"
    onNext_click --> idle : controller.next().then(startRound)
    idle --> playing_cadence : ROUND_STARTED

    state FeedbackPanel {
        [*] --> pass_badges : outcome.pitch && outcome.label
        [*] --> fail_badges : !outcome.pitch || !outcome.label
        pass_badges --> explanation
        fail_badges --> explanation
        explanation --> tooltip_shown : showTooltip = true
        explanation --> no_tooltip : showTooltip = false
        [*] --> PitchNullHint : consecutiveNullCount >= 3
    }
```

## Summary

- Adds `FeedbackPanel.svelte`: F2 result panel with pitch ✓/✗ + cents readout, label ✓/✗ + spoken digit, plain-English explanation, optional per-degree function tooltip (major/minor), and `PitchNullHint` after 3+ consecutive null frames
- Adds `PitchNullHint.svelte`: amber inline hint for mic check when pitch detection yields no signal
- Adds `function-tooltips.ts`: plain-English descriptions for all 7 degrees in major and minor
- Wires `FeedbackPanel` into the session route inside the `controller.state.kind === 'graded'` guard; exported from exercise `index.ts` (ESLint exercise-boundary rule requires public export for cross-boundary imports)

## Screenshots

Screenshots skipped — the session route boot sequence requires precise IndexedDB timing that `addInitScript` can't guarantee in headless Playwright. The panel is exercised via the dev harness at `http://localhost:5173/harness/audio.html` (force state via `window.__sessionControllerForTest._forceState({kind:'graded',...})`).

## Test plan

- [x] `pnpm run test` — 283 tests, all pass (+5 from FeedbackPanel.test.ts)
- [x] `pnpm run typecheck` — exit 0 (all packages)
- [x] `pnpm run lint` — exit 0, ESLint exercise-boundary rule satisfied via public index.ts export
- [x] FeedbackPanel shows pass badges (✓✓) on passing attempt
- [x] FeedbackPanel shows fail badge (✗) on pitch failure
- [x] Tooltip hidden when `showTooltip = false`
- [x] Plain-English explanation: "You sang 5 but said 4" on label mismatch
- [x] "Next round" button fires `onNext` callback
- [x] `PitchNullHint` rendered when `consecutiveNullCount >= 3` (store-driven)
- [x] Route no-items / loading / complete branches unchanged from PR #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)