### PR TITLE
feat(exercise): ReplayBar with simultaneous Both (Task 8)

### DIFF
--- a/apps/ear-training-station/e2e/round-graded.spec.ts
+++ b/apps/ear-training-station/e2e/round-graded.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '@playwright/test';
 import { seedOnboarded } from './helpers/app-state';
 
-// TODO(Task 7, Task 8): Un-skip once FeedbackPanel and ReplayBar are implemented.
-// This test seeds a graded state via the _forceState hook and verifies the UI
-// renders correctly. The components it expects (FeedbackPanel showing "pitch",
-// ReplayBar button named "target") do not exist until Tasks 7–8 land.
+// FeedbackPanel (Task 7) and ReplayBar (Task 8) are both implemented.
+// NOTE: This test encounters the refresh-abandon guard in +page.ts: navigating to a session
+// with ended_at=null immediately marks it complete. The controller never mounts.
+// Screenshot capture is deferred to a follow-up task that bypasses the refresh-abandon guard.
+// Keeping the test skipped until the session route supports a ?preview or e2e=1 flag.
 test.skip('graded state renders FeedbackPanel and ReplayBar (seeded via test hook)', async ({ page, context }) => {
   await context.grantPermissions(['microphone']);
   await seedOnboarded(page);

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/index.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/index.ts
@@ -16,3 +16,4 @@ export { createSessionController } from './internal/session-controller.svelte';
 export type { SessionController, SessionControllerDeps } from './internal/session-controller.svelte';
 export { default as ActiveRound } from './internal/ActiveRound.svelte';
 export { default as FeedbackPanel } from './internal/FeedbackPanel.svelte';
+export { default as ReplayBar } from './internal/ReplayBar.svelte';

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ReplayBar.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ReplayBar.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+
+  type Mode = 'you' | 'target' | 'both';
+
+  let {
+    userBuffer,
+    targetBuffer,
+  }: {
+    userBuffer: AudioBuffer | null;
+    targetBuffer: AudioBuffer | null;
+  } = $props();
+
+  let mode = $state<Mode>('target');
+  let playing = $state(false);
+  let ctx: AudioContext | null = null;
+  let sources: AudioBufferSourceNode[] = [];
+
+  function ensureCtx(): AudioContext {
+    if (!ctx) ctx = new AudioContext();
+    return ctx;
+  }
+
+  function playBuffer(buf: AudioBuffer, destCtx: AudioContext): AudioBufferSourceNode {
+    const src = destCtx.createBufferSource();
+    src.buffer = buf;
+    src.connect(destCtx.destination);
+    src.start();
+    return src;
+  }
+
+  function play() {
+    if (playing) return;
+    const c = ensureCtx();
+    sources = [];
+    if (mode === 'you' && userBuffer) sources.push(playBuffer(userBuffer, c));
+    if (mode === 'target' && targetBuffer) sources.push(playBuffer(targetBuffer, c));
+    if (mode === 'both') {
+      if (userBuffer) sources.push(playBuffer(userBuffer, c));
+      if (targetBuffer) sources.push(playBuffer(targetBuffer, c));
+    }
+    playing = true;
+    const longest = Math.max(
+      ...sources.map((s) => (s.buffer?.duration ?? 0)),
+    );
+    setTimeout(() => {
+      playing = false;
+      sources = [];
+    }, longest * 1000 + 50);
+  }
+
+  function stop() {
+    sources.forEach((s) => { try { s.stop(); } catch { /* already stopped */ } });
+    sources = [];
+    playing = false;
+  }
+
+  onDestroy(() => {
+    stop();
+    void ctx?.close();
+  });
+</script>
+
+<div class="replay-bar">
+  <div class="modes" role="radiogroup" aria-label="Replay source">
+    <button
+      type="button"
+      class:active={mode === 'you'}
+      disabled={!userBuffer}
+      onclick={() => (mode = 'you')}
+      aria-label="You"
+    >
+      <span class="dot you-dot" aria-hidden="true"></span>
+      You
+    </button>
+    <button
+      type="button"
+      class:active={mode === 'target'}
+      disabled={!targetBuffer}
+      onclick={() => (mode = 'target')}
+      aria-label="Target"
+    >
+      <span class="dot target-dot" aria-hidden="true"></span>
+      Target
+    </button>
+    <button
+      type="button"
+      class:active={mode === 'both'}
+      disabled={!userBuffer || !targetBuffer}
+      onclick={() => (mode = 'both')}
+      aria-label="Both"
+    >
+      Both
+    </button>
+  </div>
+  <button
+    type="button"
+    class="play"
+    disabled={playing}
+    onclick={play}
+    aria-label={playing ? 'Playing' : 'Play'}
+  >
+    {playing ? '▶ Playing…' : '▶ Play'}
+  </button>
+</div>
+
+<style>
+  .replay-bar {
+    display: flex; gap: 8px; align-items: center;
+    padding: 10px 12px; border: 1px solid var(--border); border-radius: 6px;
+    margin-top: 12px;
+  }
+  .modes {
+    display: flex; gap: 0; overflow: hidden;
+    border-radius: 4px; border: 1px solid var(--border);
+  }
+  .modes button {
+    padding: 6px 12px; border: none; background: transparent;
+    color: var(--muted); font-size: 11px;
+    display: inline-flex; align-items: center; gap: 6px;
+  }
+  .modes button.active {
+    background: var(--panel);
+    color: var(--text);
+    box-shadow: inset 0 0 0 1px var(--cyan);
+  }
+  .modes button:disabled {
+    opacity: 0.4; cursor: not-allowed;
+  }
+  .dot { width: 6px; height: 6px; border-radius: 50%; }
+  .you-dot { background: var(--amber); }
+  .target-dot { background: var(--cyan); }
+  .play {
+    padding: 6px 12px; border: 1px solid var(--cyan); background: transparent;
+    color: var(--cyan); border-radius: 4px; font-size: 11px;
+    margin-left: auto;
+  }
+  .play:disabled {
+    opacity: 0.6;
+  }
+</style>

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ReplayBar.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ReplayBar.svelte
@@ -15,6 +15,13 @@
   let playing = $state(false);
   let ctx: AudioContext | null = null;
   let sources: AudioBufferSourceNode[] = [];
+  let resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const canPlay = $derived(
+    (mode === 'you' && userBuffer != null) ||
+    (mode === 'target' && targetBuffer != null) ||
+    (mode === 'both' && userBuffer != null && targetBuffer != null)
+  );
 
   function ensureCtx(): AudioContext {
     if (!ctx) ctx = new AudioContext();
@@ -39,17 +46,20 @@
       if (userBuffer) sources.push(playBuffer(userBuffer, c));
       if (targetBuffer) sources.push(playBuffer(targetBuffer, c));
     }
+    if (sources.length === 0) return;
     playing = true;
     const longest = Math.max(
       ...sources.map((s) => (s.buffer?.duration ?? 0)),
     );
-    setTimeout(() => {
+    resetTimer = setTimeout(() => {
+      resetTimer = null;
       playing = false;
       sources = [];
     }, longest * 1000 + 50);
   }
 
   function stop() {
+    if (resetTimer != null) { clearTimeout(resetTimer); resetTimer = null; }
     sources.forEach((s) => { try { s.stop(); } catch { /* already stopped */ } });
     sources = [];
     playing = false;
@@ -96,7 +106,7 @@
   <button
     type="button"
     class="play"
-    disabled={playing}
+    disabled={playing || !canPlay}
     onclick={play}
     aria-label={playing ? 'Playing' : 'Play'}
   >

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ReplayBar.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ReplayBar.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import ReplayBar from './ReplayBar.svelte';
+
+function fakeBuffer(): AudioBuffer {
+  return {
+    duration: 1.5,
+    sampleRate: 48000,
+    numberOfChannels: 1,
+    length: 72000,
+    getChannelData: () => new Float32Array(72000),
+    copyToChannel: () => {},
+    copyFromChannel: () => {},
+  } as unknown as AudioBuffer;
+}
+
+describe('ReplayBar', () => {
+  it('renders three mode buttons', () => {
+    render(ReplayBar, { userBuffer: fakeBuffer(), targetBuffer: fakeBuffer() });
+    expect(screen.getByRole('button', { name: /you/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /target/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /both/i })).toBeInTheDocument();
+  });
+
+  it('renders a play button', () => {
+    render(ReplayBar, { userBuffer: fakeBuffer(), targetBuffer: fakeBuffer() });
+    expect(screen.getByRole('button', { name: /play/i })).toBeInTheDocument();
+  });
+
+  it('renders disabled state when userBuffer is null', () => {
+    render(ReplayBar, { userBuffer: null, targetBuffer: fakeBuffer() });
+    const youBtn = screen.getByRole('button', { name: /you/i }) as HTMLButtonElement;
+    expect(youBtn.disabled).toBe(true);
+  });
+
+  it('switches mode when user clicks Target', async () => {
+    const user = userEvent.setup();
+    render(ReplayBar, { userBuffer: fakeBuffer(), targetBuffer: fakeBuffer() });
+    await user.click(screen.getByRole('button', { name: /target/i }));
+    // Target button should now have active class
+    expect(screen.getByRole('button', { name: /target/i })).toHaveClass('active');
+  });
+});

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ReplayBar.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ReplayBar.test.ts
@@ -41,4 +41,17 @@ describe('ReplayBar', () => {
     // Target button should now have active class
     expect(screen.getByRole('button', { name: /target/i })).toHaveClass('active');
   });
+
+  it('play button is disabled when current mode has no buffer; enabled after switching to a mode with a buffer', async () => {
+    const user = userEvent.setup();
+    // Production-initial state: userBuffer present, targetBuffer null.
+    // Default mode is 'target', so Play should be disabled.
+    render(ReplayBar, { userBuffer: fakeBuffer(), targetBuffer: null });
+    const playBtn = screen.getByRole('button', { name: /play/i }) as HTMLButtonElement;
+    expect(playBtn.disabled).toBe(true);
+
+    // Click 'You' — now mode=you and userBuffer is available; Play should be enabled.
+    await user.click(screen.getByRole('button', { name: /you/i }));
+    expect(playBtn.disabled).toBe(false);
+  });
 });

--- a/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte
+++ b/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createSessionController, ActiveRound, FeedbackPanel } from '$lib/exercises/scale-degree';
+  import { createSessionController, ActiveRound, FeedbackPanel, ReplayBar } from '$lib/exercises/scale-degree';
   import { getDeps } from '$lib/shell/deps';
   import { settings } from '$lib/shell/stores';
   import { onDestroy, onMount } from 'svelte';
@@ -53,7 +53,10 @@
       showTooltip={$settings.function_tooltip}
       onNext={() => { const c = controller; if (c) void c.next().then(() => c.startRound()); }}
     />
-    <!-- ReplayBar mounts in Task 8 -->
+    <ReplayBar
+      userBuffer={controller.capturedAudio}
+      targetBuffer={controller.targetAudio}
+    />
   {/if}
 {:else if data.session.ended_at == null && noItemsDue}
   <p>No items are due right now. <a href={resolve('/')}>Return to dashboard</a></p>


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    [*] --> idle_mode: component mounts (mode=target)
    idle_mode --> you_mode: click You button
    idle_mode --> target_mode: click Target button (default active)
    idle_mode --> both_mode: click Both button
    you_mode --> target_mode: click Target
    you_mode --> both_mode: click Both
    target_mode --> you_mode: click You
    target_mode --> both_mode: click Both
    both_mode --> you_mode: click You
    both_mode --> target_mode: click Target
    idle_mode --> playing: click Play
    you_mode --> playing: click Play
    target_mode --> playing: click Play
    both_mode --> playing: click Play
    playing --> current_mode: duration + 50ms timeout

    note right of playing
      Play is disabled while playing=true.
      Both overlays userBuffer + targetBuffer
      simultaneously in the same AudioContext.
    end note
```

## Summary

- Adds `ReplayBar.svelte` — three-mode segmented replay (You / Target / Both) below FeedbackPanel in the graded state render block
- "Both" overlays user + target `AudioBuffer`s simultaneously in a shared `AudioContext` per the Q9 simultaneous-overlay design decision
- Disabled states: "You" disabled when `userBuffer` is null; "Target" disabled when `targetBuffer` is null; "Both" disabled when either is null. `controller.targetAudio` is always null until a follow-up task synthesizes via OfflineAudioContext — "Target" and "Both" are intentionally disabled for now; "You" works once capture completes.

## Screenshots

N/A — screenshot capture deferred. The `+page.ts` refresh-abandon guard (which marks any session with `ended_at=null` as complete on page load) prevents the controller from mounting via `addInitScript` IDB seeding. The `round-graded.spec.ts` Playwright test remains skipped with a clear comment explaining the blocker. Fixing the screenshot capture requires a session-route flag (e.g., `?e2e=1`) to bypass the refresh-abandon guard — tracked as a follow-up.

## Test plan

- [x] `pnpm run typecheck && pnpm run test` — green (293 tests, +4 new ReplayBar tests)
- [x] New unit / component tests added — 4 tests in `ReplayBar.test.ts` covering: three buttons render, play button renders, disabled state when userBuffer null, mode switch on click
- [x] `ReplayBar` exported from exercise index (`scale-degree/index.ts`) per `no-restricted-imports` lint rule
- [x] `pnpm run lint` — clean
- [ ] New Playwright e2e spec — skipped (see Screenshots section above)
- [ ] `pnpm run build` — not verified in headless CI context; relies on CI workflow

## Plan reference

Part of Plan C1.3, Task 8. See `docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md` lines 1961–2229.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)