### PR TITLE
feat(core/controller): attempt persistence via buildAttemptPersistence helper (Task 8.5)

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -53,6 +53,9 @@ export interface SessionController {
   /** @internal — test hook: set the running pitch/label pass counters directly,
    *  to simulate the effect of persistence having run during _forceState tests */
   _forceRunningCounters(pitch: number, label: number): void;
+  /** @internal — test hook: read the current running pitch/label pass counters
+   *  and roundIndex to verify consistency after persistence failures */
+  _getRunningCounters(): { pitch: number; label: number; roundIndex: number };
 }
 
 export function createSessionController(deps: SessionControllerDeps): SessionController {
@@ -140,13 +143,19 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
         try {
           await deps.attemptsRepo.append(attempt);
           await deps.itemsRepo.put(updatedItem);
-        } catch { /* IO error — log or degrade gracefully later */ }
-
-        // Update running counters
-        this.#reviewsInBox.set(item.id, reviewsInCurrentBox);
-        this.#roundIndex++;
-        if (pitchOk) this.#pitchPasses++;
-        if (labelOk) this.#labelPasses++;
+          // Update running counters only after both writes succeed — keeps
+          // controller state consistent with the DB on partial failure.
+          this.#reviewsInBox.set(item.id, reviewsInCurrentBox);
+          this.#roundIndex++;
+          if (pitchOk) this.#pitchPasses++;
+          if (labelOk) this.#labelPasses++;
+        } catch (e) {
+          // Persistence failed — leave counters at pre-round values so controller
+          // state stays consistent with the DB. A future C1.4 task will surface this
+          // to a shell-level degradation banner / toast.
+          // TODO(c1.4): surface persistence failure to the UI
+          console.error('session-controller: persistence failed, round not counted', e);
+        }
       }
 
       this.#onStateChange();
@@ -360,6 +369,10 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     _forceRunningCounters(pitch: number, label: number): void {
       this.#pitchPasses = pitch;
       this.#labelPasses = label;
+    }
+
+    _getRunningCounters(): { pitch: number; label: number; roundIndex: number } {
+      return { pitch: this.#pitchPasses, label: this.#labelPasses, roundIndex: this.#roundIndex };
     }
   }
 

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -12,6 +12,9 @@ import type { RecorderHandle } from '@ear-training/web-platform/mic/recorder';
 import { gradeListeningState } from '@ear-training/core/round/grade-listening';
 import { pickTimbre, pickRegister, type VariabilityHistory, type TimbreId } from '@ear-training/core/variability/pickers';
 import { availableRegisters } from '@ear-training/core/scheduler/register-gating';
+import { buildAttemptPersistence } from '@ear-training/core/round/persistence';
+import { nextBoxOnPass, nextBoxOnMiss } from '@ear-training/core/srs/leitner';
+import { SvelteMap } from 'svelte/reactivity';
 import { consecutiveNullCount } from '$lib/shell/stores';
 
 export interface SessionControllerDeps {
@@ -47,6 +50,9 @@ export interface SessionController {
   _pickVariability(items: ReadonlyArray<Item>): { timbre: TimbreId; register: Register };
   /** @internal — test hook: simulate a pitch frame arriving from the detector */
   _onPitchFrame(frame: { hz: number; confidence: number }): void;
+  /** @internal — test hook: set the running pitch/label pass counters directly,
+   *  to simulate the effect of persistence having run during _forceState tests */
+  _forceRunningCounters(pitch: number, label: number): void;
 }
 
 export function createSessionController(deps: SessionControllerDeps): SessionController {
@@ -66,6 +72,14 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     #history: VariabilityHistory = { lastTimbre: null, lastRegister: null };
     #rng: () => number = deps.rng ?? Math.random;
 
+    // Persistence state — maintained across rounds
+    #reviewsInBox: SvelteMap<string, number> = new SvelteMap();
+    #roundIndex: number = deps.session.completed_items;
+    #pitchPasses: number = deps.session.pitch_pass_count;
+    #labelPasses: number = deps.session.label_pass_count;
+    // Target hz stored at startRound time for use in attempt persistence
+    #currentTargetHz: number = 0;
+
     async #dispatch(event: RoundEvent): Promise<void> {
       const prev = this.state.kind;
       this.state = roundReducer(this.state, event);
@@ -84,6 +98,55 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
             this.capturedAudio = await this.#recorderHandle.stop();
           } catch { /* ignore */ }
         }
+
+        // Persist the attempt and update item SRS state.
+        // Use at_ms from the CAPTURE_COMPLETE event as the clock source.
+        const gradedState = this.state as Extract<RoundState, { kind: 'graded' }>;
+        const item = gradedState.item;
+        const now = event.type === 'CAPTURE_COMPLETE' ? event.at_ms : Date.now();
+        const pitchOk = gradedState.outcome.pitch;
+        const labelOk = gradedState.outcome.label;
+
+        const prevReviews = this.#reviewsInBox.get(item.id) ?? 0;
+        // Compute nextBox to determine reviewsInCurrentBox
+        const consecutivePassesAfter = pitchOk && labelOk ? item.consecutive_passes + 1 : 0;
+        const nextBox = pitchOk && labelOk
+          ? nextBoxOnPass(item.box, consecutivePassesAfter)
+          : nextBoxOnMiss(item.box);
+        const reviewsInCurrentBox = nextBox === item.box ? prevReviews + 1 : 0;
+
+        const { attempt, updatedItem } = buildAttemptPersistence({
+          item,
+          sessionId: deps.session.id,
+          roundIndex: this.#roundIndex,
+          reviewsInCurrentBox,
+          now,
+          target: { hz: this.#currentTargetHz },
+          sung: {
+            hz: gradedState.sungBest?.hz ?? null,
+            cents_off: gradedState.cents_off,
+            confidence: gradedState.sungBest?.confidence ?? 0,
+          },
+          spoken: {
+            digit: gradedState.digitHeard,
+            confidence: gradedState.digitConfidence,
+          },
+          pitchOk,
+          labelOk,
+          timbre: gradedState.timbre,
+          register: gradedState.register,
+        });
+
+        try {
+          await deps.attemptsRepo.append(attempt);
+          await deps.itemsRepo.put(updatedItem);
+        } catch { /* IO error — log or degrade gracefully later */ }
+
+        // Update running counters
+        this.#reviewsInBox.set(item.id, reviewsInCurrentBox);
+        this.#roundIndex++;
+        if (pitchOk) this.#pitchPasses++;
+        if (labelOk) this.#labelPasses++;
       }
 
       this.#onStateChange();
@@ -162,6 +225,7 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
 
       const cadence = buildCadence(this.currentItem.key);
       const target = buildTarget(this.currentItem.key, this.currentItem.degree, register);
+      this.#currentTargetHz = target.hz;
       this.#playHandle = playRound({ timbreId: timbre, cadence, target, gapSec: 0.2 });
 
       void this.#dispatch({ type: 'CADENCE_STARTED', at_ms: Date.now() });
@@ -199,16 +263,16 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       consecutiveNullCount.set(0);
 
       const sessionRow = this.session!;
-      const gradedState = this.state;
       const completed = sessionRow.completed_items + 1;
 
       if (completed >= sessionRow.target_items) {
         // Session is full — complete it, do not start another round.
+        // Running counters (#pitchPasses / #labelPasses) already include this round's outcome.
         await deps.sessionsRepo.complete(sessionRow.id, {
           ended_at: Date.now(),
           completed_items: completed,
-          pitch_pass_count: sessionRow.pitch_pass_count + (gradedState.outcome.pitch ? 1 : 0),
-          label_pass_count: sessionRow.label_pass_count + (gradedState.outcome.label ? 1 : 0),
+          pitch_pass_count: this.#pitchPasses,
+          label_pass_count: this.#labelPasses,
           focus_item_id: sessionRow.focus_item_id,
         });
         this.session = { ...sessionRow, ended_at: Date.now(), completed_items: completed };
@@ -226,8 +290,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
         await deps.sessionsRepo.complete(sessionRow.id, {
           ended_at: Date.now(),
           completed_items: completed,
-          pitch_pass_count: sessionRow.pitch_pass_count + (gradedState.outcome.pitch ? 1 : 0),
-          label_pass_count: sessionRow.label_pass_count + (gradedState.outcome.label ? 1 : 0),
+          pitch_pass_count: this.#pitchPasses,
+          label_pass_count: this.#labelPasses,
           focus_item_id: sessionRow.focus_item_id,
         });
         this.session = { ...sessionRow, ended_at: Date.now(), completed_items: completed };
@@ -291,6 +355,11 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
 
     _forceTimer(id: number): void {
       this.#captureEndTimer = id;
+    }
+
+    _forceRunningCounters(pitch: number, label: number): void {
+      this.#pitchPasses = pitch;
+      this.#labelPasses = label;
     }
   }
 

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -5,6 +5,14 @@ import type { Item, Session } from '@ear-training/core/types/domain';
 import type { RoundState } from '@ear-training/core/round/state';
 import { consecutiveNullCount } from '$lib/shell/stores';
 
+/** Flush all pending microtasks so async fire-and-forget dispatches complete. */
+async function flushPromises(): Promise<void> {
+  // Multiple ticks to drain chained awaits (recorder.stop, append, put)
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
 const baseItem: Item = {
   id: '5-C-major',
   degree: 5,
@@ -214,6 +222,10 @@ describe('SessionController — next()', () => {
     const ctrl = createSessionController({ ...deps, session, firstItem: baseItem });
 
     ctrl._forceState(gradedState);
+    // Simulate persistence having run for this round:
+    // #pitchPasses and #labelPasses are updated when graded transition fires.
+    // _forceState bypasses dispatch, so we advance the running counters manually.
+    ctrl._forceRunningCounters(16, 19); // 15+1 pitch pass, 18+1 label pass
 
     await ctrl.next();
 
@@ -225,8 +237,8 @@ describe('SessionController — next()', () => {
       'sess-1',
       expect.objectContaining({
         completed_items: 30,
-        pitch_pass_count: 16, // 15 + 1 for the passing outcome
-        label_pass_count: 19, // 18 + 1
+        pitch_pass_count: 16, // running counter (15 + 1 from this round)
+        label_pass_count: 19, // running counter (18 + 1 from this round)
       }),
     );
   });
@@ -255,6 +267,104 @@ describe('SessionController — next()', () => {
 
     await expect(ctrl.next()).resolves.toBeUndefined();
     expect(deps.sessionsRepo.complete).not.toHaveBeenCalled();
+  });
+});
+
+describe('SessionController — attempt persistence on graded transition', () => {
+  // Helper: build a CAPTURE_COMPLETE-like graded state via _checkCaptureEnd.
+  // Uses _forceState to set up the listening state, then calls _checkCaptureEnd
+  // to trigger the real graded transition including persistence.
+  function setupListening(ctrl: ReturnType<typeof createSessionController>) {
+    ctrl._forceState({
+      kind: 'listening',
+      item: baseItem,
+      timbre: 'piano',
+      register: 'comfortable',
+      targetStartedAt: 0,
+      frames: [{ at_ms: 100, hz: 392, confidence: 0.95 }],
+      digit: 5,
+      digitConfidence: 0.9,
+    } as never);
+  }
+
+  it('calls attemptsRepo.append exactly once on graded transition', async () => {
+    const deps = makeDeps();
+    const ctrl = createSessionController(deps);
+
+    setupListening(ctrl);
+    ctrl._checkCaptureEnd();
+
+    // #dispatch is async fire-and-forget; flush all pending microtasks.
+    await flushPromises();
+
+    expect(deps.attemptsRepo.append).toHaveBeenCalledOnce();
+  });
+
+  it('calls itemsRepo.put exactly once with the updated item', async () => {
+    const deps = makeDeps();
+    const ctrl = createSessionController(deps);
+
+    setupListening(ctrl);
+    ctrl._checkCaptureEnd();
+    await flushPromises();
+
+    expect(deps.itemsRepo.put).toHaveBeenCalledOnce();
+    const putArg = (deps.itemsRepo.put as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Item;
+    expect(putArg.id).toBe(baseItem.id);
+    expect(putArg.attempts).toBe(1);
+    // new → learning on first pass (pitch+label both pass above threshold)
+    expect(putArg.box).toBe('learning');
+  });
+
+  it('attempt has correct session_id, item_id, and graded shape', async () => {
+    const deps = makeDeps();
+    const ctrl = createSessionController(deps);
+
+    setupListening(ctrl);
+    ctrl._checkCaptureEnd();
+    await flushPromises();
+
+    const appendArg = (deps.attemptsRepo.append as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
+      session_id: string;
+      item_id: string;
+      graded: { pitch: boolean; label: boolean; pass: boolean };
+    };
+    expect(appendArg.session_id).toBe('sess-1');
+    expect(appendArg.item_id).toBe(baseItem.id);
+    // Both pitch and label pass (hz=392 ≈ G4 = degree 5 of C major; digit=5 = degree 5)
+    expect(appendArg.graded.pass).toBe(true);
+  });
+
+  it('running #pitchPasses / #labelPasses are reflected in session completion', async () => {
+    const deps = makeDeps();
+    deps.itemsRepo.findDue = vi.fn(async () => []);
+    const session: Session = {
+      ...baseSession,
+      completed_items: 5,
+      target_items: 30,
+      pitch_pass_count: 3,
+      label_pass_count: 2,
+    };
+    const ctrl = createSessionController({ ...deps, session, firstItem: baseItem });
+
+    // Transition through real graded path (not _forceState bypass)
+    setupListening(ctrl);
+    ctrl._checkCaptureEnd();
+    // Flush all async persistence work before calling next()
+    await flushPromises();
+
+    // Now next() should see the updated running counters
+    await ctrl.next();
+
+    // pitch_pass_count: 3 (init) + 1 (this round pitch pass) = 4
+    // label_pass_count: 2 (init) + 1 (this round label pass) = 3
+    expect(deps.sessionsRepo.complete).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({
+        pitch_pass_count: 4,
+        label_pass_count: 3,
+      }),
+    );
   });
 });
 

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -368,6 +368,67 @@ describe('SessionController — attempt persistence on graded transition', () =>
   });
 });
 
+describe('SessionController — persistence failure counter consistency', () => {
+  // Helper shared with the persistence suite above.
+  function setupListening(ctrl: ReturnType<typeof createSessionController>) {
+    ctrl._forceState({
+      kind: 'listening',
+      item: baseItem,
+      timbre: 'piano',
+      register: 'comfortable',
+      targetStartedAt: 0,
+      frames: [{ at_ms: 100, hz: 392, confidence: 0.95 }],
+      digit: 5,
+      digitConfidence: 0.9,
+    } as never);
+  }
+
+  it('does not advance counters when itemsRepo.put rejects', async () => {
+    const deps = makeDeps();
+    // append succeeds; put fails — simulates quota-exceeded on the second write.
+    deps.itemsRepo.put = vi.fn(async () => { throw new Error('quota exceeded'); });
+    const ctrl = createSessionController(deps);
+
+    // Verify counters start at the session baseline.
+    expect(ctrl._getRunningCounters()).toEqual({ pitch: 0, label: 0, roundIndex: 0 });
+
+    setupListening(ctrl);
+    ctrl._checkCaptureEnd();
+    // Flush all async microtasks so the try/catch inside #dispatch completes.
+    await flushPromises();
+
+    // append was called (partial failure path confirmed).
+    expect(deps.attemptsRepo.append).toHaveBeenCalledOnce();
+    // put threw — counters must remain at pre-round values.
+    expect(ctrl._getRunningCounters()).toEqual({ pitch: 0, label: 0, roundIndex: 0 });
+  });
+
+  it('does not advance counters when attemptsRepo.append rejects', async () => {
+    const deps = makeDeps();
+    deps.attemptsRepo.append = vi.fn(async () => { throw new Error('db closed'); });
+    const ctrl = createSessionController(deps);
+
+    setupListening(ctrl);
+    ctrl._checkCaptureEnd();
+    await flushPromises();
+
+    expect(deps.itemsRepo.put).not.toHaveBeenCalled();
+    expect(ctrl._getRunningCounters()).toEqual({ pitch: 0, label: 0, roundIndex: 0 });
+  });
+
+  it('advances counters normally when both writes succeed', async () => {
+    const deps = makeDeps();
+    const ctrl = createSessionController(deps);
+
+    setupListening(ctrl);
+    ctrl._checkCaptureEnd();
+    await flushPromises();
+
+    // pitch and label both pass (hz≈392 = G4 = degree 5 of C major; digit=5).
+    expect(ctrl._getRunningCounters()).toEqual({ pitch: 1, label: 1, roundIndex: 1 });
+  });
+});
+
 describe('SessionController — consecutiveNullCount store', () => {
   beforeEach(() => {
     // Reset store between tests to avoid leakage.

--- a/docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md
+++ b/docs/plans/2026-04-16-plan-c1-3-scale-degree-exercise.md
@@ -2228,6 +2228,34 @@ Part of Plan C1.3.
 
 ---
 
+### Task 8.5: Attempt persistence via pure core helper
+
+**Goal:** Close the gap surfaced in the PR #85 review: `SessionController` was grading in-memory but never persisting attempts or item SRS updates to `attemptsRepo`/`itemsRepo`. This means Leitner box transitions, accuracy updates, and `due_at` were all silently lost between sessions.
+
+The fix extracts the pure math from `orchestrator.recordAttempt()` into a stateless helper `buildAttemptPersistence`, refactors the orchestrator to use it (no behavior change), and wires the controller's `listening → graded` transition to call the helper and write to both repos.
+
+**Files:**
+- Create: `packages/core/src/round/persistence.ts` — `BuildAttemptInput` interface + `buildAttemptPersistence()` pure function
+- Create: `packages/core/tests/round/persistence.test.ts` — 7 unit tests for the helper
+- Modify: `packages/core/src/session/orchestrator.ts` — refactor `recordAttempt()` to delegate to helper (same external behavior)
+- Modify: `apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts` — add private persistence state (`#reviewsInBox`, `#roundIndex`, `#pitchPasses`, `#labelPasses`, `#currentTargetHz`) and wire graded-transition persistence
+- Modify: `apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts` — add 4 new persistence tests, update `next()` completion test to use `_forceRunningCounters` hook
+
+**TDD steps:**
+- [ ] Write failing `buildAttemptPersistence` test (module not found)
+- [ ] Implement `packages/core/src/round/persistence.ts`
+- [ ] Refactor orchestrator to use helper — orchestrator tests unchanged
+- [ ] Write failing controller persistence tests
+- [ ] Wire `#dispatch` graded-transition + `next()` counter usage
+- [ ] `pnpm run typecheck && pnpm run test && pnpm run lint` — all green
+
+**Commit:**
+```
+feat(core/controller): attempt persistence via buildAttemptPersistence helper (Task 8.5)
+```
+
+---
+
 ### Task 9: `DashboardView.svelte`
 
 The exercise dashboard — mastery bars per degree, key heatmap, Leitner pipeline, Start CTA.

--- a/packages/core/src/round/persistence.ts
+++ b/packages/core/src/round/persistence.ts
@@ -1,0 +1,90 @@
+import type { Attempt, AttemptOutcome, Item, Register } from '@/types/domain';
+import type { Degree } from '@/types/music';
+import { nextBoxOnPass, nextBoxOnMiss, dueAtAfter } from '@/srs/leitner';
+import { weightedAccuracy, pushOutcome } from '@/srs/accuracy';
+
+export interface BuildAttemptInput {
+  item: Item;
+  sessionId: string;
+  /**
+   * Zero-based index of this round within the session; used to construct the
+   * attempt id as `${sessionId}-${roundIndex}-${item.id}`.
+   */
+  roundIndex: number;
+  /**
+   * How many times this item has already been reviewed in its current box
+   * BEFORE this attempt. Caller is responsible for maintaining this counter
+   * and computing the next value.
+   */
+  reviewsInCurrentBox: number;
+  now: number;
+  target: { hz: number };
+  sung: { hz: number | null; cents_off: number | null; confidence: number };
+  spoken: { digit: Degree | null; confidence: number };
+  pitchOk: boolean;
+  labelOk: boolean;
+  timbre: string;
+  register: Register;
+}
+
+export interface BuildAttemptResult {
+  attempt: Attempt;
+  updatedItem: Item;
+}
+
+/**
+ * Pure, stateless helper that computes the persisted `Attempt` record and the
+ * updated `Item` (Leitner box, accuracy, consecutive_passes, due_at) from a
+ * single graded round.
+ *
+ * Does NO I/O. Callers are responsible for writing `attempt` and `updatedItem`
+ * to their respective repos.
+ */
+export function buildAttemptPersistence(input: BuildAttemptInput): BuildAttemptResult {
+  const {
+    item, sessionId, roundIndex, reviewsInCurrentBox, now,
+    target, sung, spoken, pitchOk, labelOk, timbre, register,
+  } = input;
+
+  const outcome: AttemptOutcome = {
+    pitch: pitchOk,
+    label: labelOk,
+    pass: pitchOk && labelOk,
+    at: now,
+  };
+
+  // Compute updated item state
+  const updated: Item = {
+    ...item,
+    attempts: item.attempts + 1,
+    consecutive_passes: outcome.pass ? item.consecutive_passes + 1 : 0,
+    recent: pushOutcome(item.recent, outcome),
+    last_seen_at: now,
+  };
+  updated.accuracy = {
+    pitch: weightedAccuracy(updated.recent, 'pitch'),
+    label: weightedAccuracy(updated.recent, 'label'),
+  };
+
+  const nextBox = outcome.pass
+    ? nextBoxOnPass(item.box, updated.consecutive_passes)
+    : nextBoxOnMiss(item.box);
+
+  updated.box = nextBox;
+  updated.due_at = dueAtAfter(nextBox, reviewsInCurrentBox, now);
+
+  const attempt: Attempt = {
+    id: `${sessionId}-${roundIndex}-${item.id}`,
+    item_id: item.id,
+    session_id: sessionId,
+    at: now,
+    target: { hz: target.hz, degree: item.degree },
+    sung,
+    spoken,
+    graded: outcome,
+    timbre,
+    register,
+  };
+
+  return { attempt, updatedItem: updated };
+}

--- a/packages/core/src/session/orchestrator.ts
+++ b/packages/core/src/session/orchestrator.ts
@@ -1,10 +1,10 @@
-import type { Attempt, AttemptOutcome, Item, LeitnerBox, Register, Session } from '@/types/domain';
+import type { AttemptOutcome, Item, LeitnerBox, Register, Session } from '@/types/domain';
 import type { Degree } from '@/types/music';
 import type { ItemsRepo, AttemptsRepo, SessionsRepo } from '@/repos/interfaces';
 import { selectNextItem } from '@/scheduler/selection';
 import type { RoundHistoryEntry } from '@/scheduler/interleaving';
-import { nextBoxOnPass, nextBoxOnMiss, dueAtAfter } from '@/srs/leitner';
-import { weightedAccuracy, pushOutcome } from '@/srs/accuracy';
+import { nextBoxOnPass, nextBoxOnMiss } from '@/srs/leitner';
+import { buildAttemptPersistence } from '@/round/persistence';
 
 export interface OrchestratorDeps {
   itemsRepo: ItemsRepo;
@@ -81,59 +81,38 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
     async recordAttempt(input) {
       if (!started || currentSessionId === null) throw new Error('session not started');
       const now = deps.now();
-      const outcome: AttemptOutcome = {
-        pitch: input.pitchOk,
-        label: input.labelOk,
-        pass: input.pitchOk && input.labelOk,
-        at: now,
-      };
 
-      // Update item
-      const updated: Item = {
-        ...input.item,
-        attempts: input.item.attempts + 1,
-        consecutive_passes: outcome.pass ? input.item.consecutive_passes + 1 : 0,
-        recent: pushOutcome(input.item.recent, outcome),
-        last_seen_at: now,
-      };
-      updated.accuracy = {
-        pitch: weightedAccuracy(updated.recent, 'pitch'),
-        label: weightedAccuracy(updated.recent, 'label'),
-      };
-      const nextBox = outcome.pass
-        ? nextBoxOnPass(input.item.box, updated.consecutive_passes)
+      // Pre-compute nextBox to determine reviewsInCurrentBox before calling helper
+      const consecutivePassesAfter = input.pitchOk && input.labelOk
+        ? input.item.consecutive_passes + 1
+        : 0;
+      const nextBox = input.pitchOk && input.labelOk
+        ? nextBoxOnPass(input.item.box, consecutivePassesAfter)
         : nextBoxOnMiss(input.item.box);
       const reviewsInCurrentBox = nextBox === input.item.box
         ? (reviewsInBox.get(input.item.id) ?? 0) + 1
         : 0;
       reviewsInBox.set(input.item.id, reviewsInCurrentBox);
-      updated.box = nextBox;
-      updated.due_at = dueAtAfter(nextBox, reviewsInCurrentBox, now);
-      await deps.itemsRepo.put(updated);
 
-      // Record attempt
-      const attempt: Attempt = {
-        id: `${currentSessionId}-${completedItems}-${input.item.id}`,
-        item_id: input.item.id,
-        session_id: currentSessionId,
-        at: now,
-        target: { hz: input.target.hz, degree: input.item.degree },
-        sung: input.sung,
-        spoken: input.spoken,
-        graded: outcome,
-        timbre: input.timbre,
-        register: input.register,
-      };
+      const { attempt, updatedItem } = buildAttemptPersistence({
+        ...input,
+        sessionId: currentSessionId,
+        roundIndex: completedItems,
+        reviewsInCurrentBox,
+        now,
+      });
+
+      await deps.itemsRepo.put(updatedItem);
       await deps.attemptsRepo.append(attempt);
 
       // Update session bookkeeping
       completedItems++;
-      if (outcome.pitch) pitchPasses++;
-      if (outcome.label) labelPasses++;
+      if (attempt.graded.pitch) pitchPasses++;
+      if (attempt.graded.label) labelPasses++;
 
       history.push({ itemId: input.item.id, degree: input.item.degree, key: input.item.key });
 
-      return outcome;
+      return attempt.graded;
     },
 
     async completeSession() {

--- a/packages/core/tests/round/persistence.test.ts
+++ b/packages/core/tests/round/persistence.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import { buildAttemptPersistence } from '@/round/persistence';
+import type { Item } from '@/types/domain';
+
+const baseItem: Item = {
+  id: '5-C-major',
+  degree: 5,
+  key: { tonic: 'C', quality: 'major' },
+  box: 'new',
+  accuracy: { pitch: 0, label: 0 },
+  recent: [],
+  attempts: 0,
+  consecutive_passes: 0,
+  last_seen_at: null,
+  due_at: 0,
+  created_at: 0,
+};
+
+describe('buildAttemptPersistence', () => {
+  it('promotes box from new → learning on a passing attempt', () => {
+    const { updatedItem } = buildAttemptPersistence({
+      item: baseItem,
+      sessionId: 'sess-1',
+      roundIndex: 0,
+      reviewsInCurrentBox: 0,
+      now: 1000,
+      target: { hz: 392 },
+      sung: { hz: 392, cents_off: 0, confidence: 0.95 },
+      spoken: { digit: 5, confidence: 0.9 },
+      pitchOk: true,
+      labelOk: true,
+      timbre: 'piano',
+      register: 'comfortable',
+    });
+
+    // new → learning on first pass
+    expect(updatedItem.box).toBe('learning');
+  });
+
+  it('keeps box on new after a miss', () => {
+    const { updatedItem } = buildAttemptPersistence({
+      item: baseItem,
+      sessionId: 'sess-1',
+      roundIndex: 0,
+      reviewsInCurrentBox: 0,
+      now: 1000,
+      target: { hz: 392 },
+      sung: { hz: 300, cents_off: 150, confidence: 0.5 },
+      spoken: { digit: 3, confidence: 0.7 },
+      pitchOk: false,
+      labelOk: false,
+      timbre: 'piano',
+      register: 'comfortable',
+    });
+
+    // new → new on miss (nextBoxOnMiss('new') = 'new')
+    expect(updatedItem.box).toBe('new');
+  });
+
+  it('increments attempts and recomputes accuracy on pass', () => {
+    const { updatedItem } = buildAttemptPersistence({
+      item: baseItem,
+      sessionId: 'sess-1',
+      roundIndex: 0,
+      reviewsInCurrentBox: 0,
+      now: 1000,
+      target: { hz: 392 },
+      sung: { hz: 392, cents_off: 0, confidence: 0.95 },
+      spoken: { digit: 5, confidence: 0.9 },
+      pitchOk: true,
+      labelOk: true,
+      timbre: 'piano',
+      register: 'comfortable',
+    });
+
+    expect(updatedItem.attempts).toBe(1);
+    // pitch accuracy: one pass in window of size 1 → 1.0
+    expect(updatedItem.accuracy.pitch).toBe(1);
+    expect(updatedItem.accuracy.label).toBe(1);
+  });
+
+  it('resets consecutive_passes to 0 on miss, increments on pass', () => {
+    const itemWith2Passes: Item = { ...baseItem, consecutive_passes: 2 };
+
+    const { updatedItem: afterPass } = buildAttemptPersistence({
+      item: itemWith2Passes,
+      sessionId: 'sess-1',
+      roundIndex: 0,
+      reviewsInCurrentBox: 0,
+      now: 1000,
+      target: { hz: 392 },
+      sung: { hz: 392, cents_off: 0, confidence: 0.95 },
+      spoken: { digit: 5, confidence: 0.9 },
+      pitchOk: true,
+      labelOk: true,
+      timbre: 'piano',
+      register: 'comfortable',
+    });
+    expect(afterPass.consecutive_passes).toBe(3);
+
+    const { updatedItem: afterMiss } = buildAttemptPersistence({
+      item: itemWith2Passes,
+      sessionId: 'sess-1',
+      roundIndex: 0,
+      reviewsInCurrentBox: 0,
+      now: 1000,
+      target: { hz: 392 },
+      sung: { hz: 300, cents_off: 150, confidence: 0.5 },
+      spoken: { digit: 3, confidence: 0.7 },
+      pitchOk: false,
+      labelOk: false,
+      timbre: 'piano',
+      register: 'comfortable',
+    });
+    expect(afterMiss.consecutive_passes).toBe(0);
+  });
+
+  it('builds attempt with correct id and shape', () => {
+    const { attempt } = buildAttemptPersistence({
+      item: baseItem,
+      sessionId: 'sess-42',
+      roundIndex: 7,
+      reviewsInCurrentBox: 0,
+      now: 5000,
+      target: { hz: 392 },
+      sung: { hz: 392, cents_off: 0, confidence: 0.95 },
+      spoken: { digit: 5, confidence: 0.9 },
+      pitchOk: true,
+      labelOk: true,
+      timbre: 'guitar',
+      register: 'narrow',
+    });
+
+    expect(attempt.id).toBe('sess-42-7-5-C-major');
+    expect(attempt.item_id).toBe('5-C-major');
+    expect(attempt.session_id).toBe('sess-42');
+    expect(attempt.at).toBe(5000);
+    expect(attempt.target).toEqual({ hz: 392, degree: 5 });
+    expect(attempt.timbre).toBe('guitar');
+    expect(attempt.register).toBe('narrow');
+    expect(attempt.graded.pass).toBe(true);
+    expect(attempt.graded.at).toBe(5000);
+  });
+
+  it('attempt graded fields reflect pitchOk / labelOk inputs', () => {
+    const { attempt } = buildAttemptPersistence({
+      item: baseItem,
+      sessionId: 'sess-1',
+      roundIndex: 0,
+      reviewsInCurrentBox: 0,
+      now: 2000,
+      target: { hz: 392 },
+      sung: { hz: 300, cents_off: 90, confidence: 0.6 },
+      spoken: { digit: 3, confidence: 0.7 },
+      pitchOk: false,
+      labelOk: true,
+      timbre: 'piano',
+      register: 'comfortable',
+    });
+
+    expect(attempt.graded.pitch).toBe(false);
+    expect(attempt.graded.label).toBe(true);
+    expect(attempt.graded.pass).toBe(false); // pitch failed → overall fail
+    expect(attempt.graded.at).toBe(2000);
+  });
+
+  it('due_at advances when box stays the same (reviewsInCurrentBox increments)', () => {
+    // item already in 'learning' box with several previous reviews
+    const learningItem: Item = {
+      ...baseItem,
+      box: 'learning',
+      consecutive_passes: 0,
+    };
+    // Miss → stays in learning; reviewsInCurrentBox = 2
+    const { updatedItem } = buildAttemptPersistence({
+      item: learningItem,
+      sessionId: 'sess-1',
+      roundIndex: 0,
+      reviewsInCurrentBox: 2,
+      now: 1000,
+      target: { hz: 392 },
+      sung: { hz: 300, cents_off: 150, confidence: 0.3 },
+      spoken: { digit: 3, confidence: 0.4 },
+      pitchOk: false,
+      labelOk: false,
+      timbre: 'piano',
+      register: 'comfortable',
+    });
+
+    // due_at should be > now (learning box always has a positive interval)
+    expect(updatedItem.due_at).toBeGreaterThan(1000);
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A[listening state] -->|CAPTURE_COMPLETE| B["#dispatch (graded transition)"]
    B --> C[buildAttemptPersistence]
    C --> D["attemptsRepo.append(attempt)"]
    C --> E["itemsRepo.put(updatedItem)"]
    B --> F["#pitchPasses++ / #labelPasses++\n#roundIndex++\n#reviewsInBox.set(...)"]
    F --> G[next() uses running counters\nnot stale sessionRow values]
```

## Summary

- Extracts the pure SRS math from `orchestrator.recordAttempt()` into a new stateless `buildAttemptPersistence()` helper in `@ear-training/core/round/persistence`; refactors orchestrator to delegate to it with no behavior change.
- Wires `SessionController`'s `listening → graded` transition (in `#dispatch`) to call the helper and write `attempt` + `updatedItem` to their repos, so Leitner box transitions, accuracy, `consecutive_passes`, and `due_at` are persisted after every round.
- Replaces the stale `sessionRow.pitch_pass_count + outcome.pitch` math in `next()` with running `#pitchPasses` / `#labelPasses` counters that are updated at graded-transition time.

## Screenshots

N/A — controller-internal wiring, no visual changes.

## Test plan

- [ ] `packages/core/tests/round/persistence.test.ts` — 7 new unit tests: pass/miss box transitions, accuracy recompute, consecutive_passes, attempt id shape, `graded` field values, `due_at` > `now`
- [ ] `packages/core/tests/session/orchestrator-unit.test.ts` — 6 existing tests unchanged (refactor only)
- [ ] `apps/.../session-controller.test.ts` — 4 new persistence tests: `attemptsRepo.append` called once, `itemsRepo.put` called once with correct shape, attempt `session_id`/`graded.pass` correct, running counters reflected in session completion
- [ ] Updated existing `next()` completion test to use `_forceRunningCounters` hook
- [ ] `pnpm run typecheck && pnpm run test && pnpm run lint` — all green; 305 tests (up from 294)