### PR TITLE
feat(shell): MicDeniedGate for denied-permission state

### DIFF
--- a/apps/ear-training-station/e2e/mic-denied.spec.ts
+++ b/apps/ear-training-station/e2e/mic-denied.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { seedOnboarded } from './helpers/app-state';
+
+test('denied mic renders the MicDeniedGate', async ({ page, context }) => {
+  await context.clearPermissions();
+  await seedOnboarded(page);
+  await page.addInitScript(() => {
+    return new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('ear-training', 1);
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => {
+        const tx = req.result.transaction('sessions', 'readwrite');
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        tx.objectStore('sessions').put({
+          id: 'sess-mic-denied', started_at: Date.now(), ended_at: null,
+          target_items: 30, completed_items: 0,
+          pitch_pass_count: 0, label_pass_count: 0, focus_item_id: null,
+        });
+      };
+    });
+  });
+  await page.goto('/scale-degree/sessions/sess-mic-denied?preview=mic-denied');
+  await expect(page.getByRole('heading', { name: /microphone access required/i })).toBeVisible();
+});

--- a/apps/ear-training-station/src/lib/shell/MicDeniedGate.svelte
+++ b/apps/ear-training-station/src/lib/shell/MicDeniedGate.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  let { onRetry }: { onRetry: () => void } = $props();
+</script>
+
+<section class="mic-denied">
+  <h2>Microphone access required</h2>
+  <p>
+    Practice rounds use your microphone to detect pitch and the degree you say.
+    Re-allow mic access in your browser's site settings, then retry.
+  </p>
+  <button type="button" class="retry" onclick={onRetry}>Retry</button>
+</section>
+
+<style>
+  .mic-denied {
+    max-width: 440px; margin: 40px auto; padding: 20px;
+    border: 1px solid var(--amber); background: #2a1e05;
+    border-radius: 8px; color: var(--text);
+  }
+  h2 { font-size: 14px; margin: 0 0 8px; color: var(--amber); }
+  p { font-size: 11px; color: var(--muted); margin: 0 0 16px; }
+  .retry {
+    padding: 8px 16px; border: 1px solid var(--cyan); background: transparent;
+    color: var(--cyan); border-radius: 4px; font-size: 11px;
+  }
+</style>

--- a/apps/ear-training-station/src/lib/shell/MicDeniedGate.test.ts
+++ b/apps/ear-training-station/src/lib/shell/MicDeniedGate.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import MicDeniedGate from './MicDeniedGate.svelte';
+
+describe('MicDeniedGate', () => {
+  it('renders guidance and a retry button', () => {
+    render(MicDeniedGate, { onRetry: () => {} });
+    expect(screen.getByText(/microphone access/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('fires onRetry when the retry button is clicked', async () => {
+    const onRetry = vi.fn();
+    render(MicDeniedGate, { onRetry });
+    await userEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte
+++ b/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte
@@ -1,18 +1,37 @@
 <script lang="ts">
   import { createSessionController, ActiveRound, FeedbackPanel, ReplayBar, SummaryView } from '$lib/exercises/scale-degree';
+  import MicDeniedGate from '$lib/shell/MicDeniedGate.svelte';
   import { getDeps } from '$lib/shell/deps';
   import { settings } from '$lib/shell/stores';
   import { onDestroy, onMount } from 'svelte';
   import { resolve } from '$app/paths';
   import { dev } from '$app/environment';
+  import { page } from '$app/state';
+  import { queryMicPermission } from '@ear-training/web-platform/mic/permission';
 
   let { data } = $props();
 
   let controller: ReturnType<typeof createSessionController> | null = $state(null);
   let noItemsDue = $state(false);
+  let micDenied = $state(false);
 
   onMount(async () => {
     if (data.session.ended_at != null) return;
+
+    // Dev/test-only preview flag forces the denied-mic gate without real permission check.
+    if (
+      (dev || import.meta.env.MODE === 'test') &&
+      page.url.searchParams.get('preview') === 'mic-denied'
+    ) {
+      micDenied = true;
+      return;
+    }
+
+    const micState = await queryMicPermission();
+    if (micState === 'denied') {
+      micDenied = true;
+      return;
+    }
 
     const deps = await getDeps();
     const items = await deps.items.findDue(Date.now());
@@ -45,7 +64,9 @@
   onDestroy(() => controller?.dispose());
 </script>
 
-{#if data.session.ended_at == null && controller}
+{#if data.session.ended_at == null && micDenied}
+  <MicDeniedGate onRetry={() => window.location.reload()} />
+{:else if data.session.ended_at == null && controller}
   <ActiveRound {controller} />
   {#if controller.state.kind === 'graded'}
     <FeedbackPanel

--- a/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.ts
+++ b/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.ts
@@ -1,4 +1,5 @@
 import { error } from '@sveltejs/kit';
+import { dev } from '$app/environment';
 import { getDeps } from '$lib/shell/deps';
 import type { CompleteSessionInput } from '@ear-training/core/repos/interfaces';
 import type { Attempt, Session } from '@ear-training/core/types/domain';
@@ -6,12 +7,16 @@ import type { Attempt, Session } from '@ear-training/core/types/domain';
 export const ssr = false;
 export const prerender = false;
 
-export async function load({ params }) {
+export async function load({ params, url }) {
   const deps = await getDeps();
   const session = await deps.sessions.get(params.id);
   if (!session) throw error(404, 'session not found');
 
-  if (session.ended_at == null) {
+  const bypassAbandon =
+    url.searchParams.get('preview') === 'mic-denied' &&
+    (dev || import.meta.env.MODE === 'test');
+
+  if (session.ended_at == null && !bypassAbandon) {
     // Refresh-abandon: roll up whatever attempts exist, mark complete.
     const attempts = await deps.attempts.findBySession(session.id);
     const rollup = rollUpAbandonedSession(attempts);


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A[onMount] --> B{ended_at != null?}
    B -- yes --> Z[return early]
    B -- no --> C{preview=mic-denied\nAND dev/test?}
    C -- yes --> D[micDenied = true → return]
    C -- no --> E[queryMicPermission]
    E -->|denied| D
    E -->|other| F[getDeps → controller construction]

    D --> G{#if micDenied}
    G -- yes --> H[MicDeniedGate rendered]
    G -- no --> I[existing ActiveRound / Loading branches]
```

```mermaid
flowchart LR
    PageTs[+page.ts load] --> BA{bypassAbandon?\npreview=mic-denied\n+ dev/test}
    BA -- yes --> skip[skip refresh-abandon\nreturn active session]
    BA -- no --> abandon[rollUpAbandonedSession\nmark complete]
```

## Summary

- Adds `MicDeniedGate.svelte` — amber-bordered panel with guidance text and a Retry button (`window.location.reload()`)
- Wires `queryMicPermission()` check in `+page.svelte` `onMount`; if `'denied'`, sets `micDenied = true` and renders the gate before the controller branch
- Adds `?preview=mic-denied` dev/test-only bypass: `+page.ts` skips refresh-abandon, `+page.svelte` forces `micDenied = true` — both gated behind `dev || import.meta.env.MODE === 'test'`
- New Playwright e2e `mic-denied.spec.ts` seeds an active session via `addInitScript` (tx.oncomplete pattern) and asserts the gate heading is visible

## Test plan

- [ ] `pnpm run typecheck` exits 0
- [ ] `pnpm run test` — 334 tests pass (2 new MicDeniedGate unit tests)
- [ ] `pnpm run lint` — clean
- [ ] `playwright test mic-denied` — 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)