### PR TITLE
test(e2e): axe-core a11y smoke — /, /scale-degree, /settings (C1.4 Task 5)

### DIFF
--- a/apps/ear-training-station/e2e/a11y.smoke.spec.ts
+++ b/apps/ear-training-station/e2e/a11y.smoke.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { seedOnboarded } from './helpers/app-state';
+
+const ROUTES = ['/', '/scale-degree', '/settings'];
+
+for (const route of ROUTES) {
+  test(`a11y smoke: ${route}`, async ({ page }) => {
+    await seedOnboarded(page);
+    await page.goto(route);
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa'])
+      .analyze();
+    const serious = results.violations.filter(
+      (v) => ['serious', 'critical'].includes(v.impact ?? ''),
+    );
+    expect(serious, JSON.stringify(serious, null, 2)).toEqual([]);
+  });
+}

--- a/apps/ear-training-station/package.json
+++ b/apps/ear-training-station/package.json
@@ -18,6 +18,7 @@
     "@ear-training/web-platform": "workspace:*"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.11.2",
     "@playwright/test": "1.59.1",
     "@sveltejs/adapter-static": "^3",
     "@sveltejs/kit": "^2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/web-platform
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.11.2
+        version: 4.11.2(playwright-core@1.59.1)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -139,6 +142,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.11.2':
+    resolution: {integrity: sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1534,6 +1542,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3274,6 +3286,11 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@axe-core/playwright@4.11.2(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.3
+      playwright-core: 1.59.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -4721,6 +4738,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.11.3: {}
 
   axobject-query@4.1.0: {}
 


### PR DESCRIPTION
## Diagrams

N/A — test-only change (no component structure altered)

## Summary

- Installs `@axe-core/playwright@4.11.2` as a devDependency in `apps/ear-training-station`
- Adds `e2e/a11y.smoke.spec.ts` with 3 tests (one per target route: `/`, `/scale-degree`, `/settings`)
- Each test seeds an onboarded state via `seedOnboarded`, navigates to the route, runs axe with `wcag2a` + `wcag2aa` tags, and asserts zero serious/critical violations
- All 3 routes pass immediately — no source fixes required

## Axe violations fixed

None. The app shell already had `<main>` wrapping the outlet, `app.html` already had `<title>Ear Training Station</title>`, and heatmap cells already carried `role="img"` + `aria-label` from the C1 dashboard work. Zero serious/critical violations on first run.

## Test plan

- [x] `pnpm --filter ear-training-station exec playwright test a11y.smoke` — 3 passed, 3.2s
- [x] `pnpm run typecheck` — exit 0
- [x] `pnpm run test` — 334 tests passed (334, up from 331)
- [x] `pnpm run lint` — exit 0

## Delta

- +3 e2e tests
- 3 files touched: `package.json`, `pnpm-lock.yaml`, `e2e/a11y.smoke.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)