### PR TITLE
fix(integration): restore happy-path after Plan C1

### DIFF
--- a/apps/ear-training-station/e2e/session-abandon.spec.ts
+++ b/apps/ear-training-station/e2e/session-abandon.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { seedOnboarded } from './helpers/app-state';
 
-test('active session (ended_at null) is abandoned on navigation and shows summary placeholder', async ({ page }) => {
+test('reloading an ongoing session abandons it and shows summary', async ({ page }) => {
   await seedOnboarded(page);
 
   await page.addInitScript(() => {
@@ -27,9 +27,11 @@ test('active session (ended_at null) is abandoned on navigation and shows summar
     });
   });
 
+  // First navigation — fresh, session remains active (no abandon).
   await page.goto('/scale-degree/sessions/active-sess-1');
 
-  // load() performs refresh-abandon: sets ended_at, so the SummaryView is shown.
+  // Reload — this triggers refresh-abandon, which sets ended_at and shows SummaryView.
+  await page.reload();
   await expect(page.getByRole('heading', { name: /done/i })).toBeVisible();
 });
 

--- a/apps/ear-training-station/package.json
+++ b/apps/ear-training-station/package.json
@@ -27,6 +27,7 @@
     "@testing-library/svelte": "5.3.1",
     "@testing-library/user-event": "14.6.1",
     "@vite-pwa/sveltekit": "1.1.0",
+    "fake-indexeddb": "6.0.0",
     "svelte": "5.55.4",
     "svelte-check": "4.4.6",
     "vite": "8.0.8",

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.integration.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.integration.test.ts
@@ -1,0 +1,102 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { createSessionController } from './session-controller.svelte';
+import { createItemsRepo } from '@ear-training/web-platform/store/items-repo';
+import { createAttemptsRepo } from '@ear-training/web-platform/store/attempts-repo';
+import { openEarTrainingDB, type DB } from '@ear-training/web-platform/store/db';
+import type { Item, Session } from '@ear-training/core/types/domain';
+import { allItems, degradationState } from '$lib/shell/stores';
+
+/** Flush microtasks AND timer macrotasks — fake-indexeddb schedules tx completion via setTimeout(0). */
+async function flushPromises(): Promise<void> {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+const baseItem: Item = {
+  id: '5-C-major',
+  degree: 5,
+  key: { tonic: 'C', quality: 'major' },
+  box: 'new',
+  accuracy: { pitch: 0, label: 0 },
+  recent: [],
+  attempts: 0,
+  consecutive_passes: 0,
+  last_seen_at: null,
+  due_at: 0,
+  created_at: 0,
+};
+
+const baseSession: Session = {
+  id: 'sess-int-1',
+  started_at: 0,
+  ended_at: null,
+  target_items: 30,
+  completed_items: 0,
+  pitch_pass_count: 0,
+  label_pass_count: 0,
+  focus_item_id: null,
+};
+
+async function makeRealDeps(db: DB) {
+  const itemsRepo = createItemsRepo(db);
+  const attemptsRepo = createAttemptsRepo(db);
+  await itemsRepo.put(baseItem);
+  return {
+    session: baseSession,
+    firstItem: baseItem,
+    itemsRepo,
+    attemptsRepo,
+    sessionsRepo: { start: vi.fn(), complete: vi.fn(), get: vi.fn(async () => baseSession), findRecent: vi.fn(async () => []) },
+    settingsRepo: {
+      getOrDefault: vi.fn(async () => ({ function_tooltip: true, auto_advance_on_hit: true, session_length: 30, reduced_motion: 'auto' as const, onboarded: true })),
+      update: vi.fn(),
+    },
+    getAudioContext: () => new (class { currentTime = 0; sampleRate = 48000; audioWorklet = { addModule: vi.fn(async () => undefined) }; createBuffer() { return {} as AudioBuffer; } createMediaStreamSource() { return { connect: vi.fn(), disconnect: vi.fn() }; } })() as unknown as AudioContext,
+    getMicStream: async () => ({} as MediaStream),
+  };
+}
+
+describe('SessionController — persistence against real IndexedDB', () => {
+  let db: DB;
+
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    db = await openEarTrainingDB('ear-training-test');
+    allItems.set([]);
+    degradationState.set({ kwsUnavailable: false, persistenceFailing: false, micLost: false });
+  });
+
+  // Regression: $state-backed RoundState exposes item/sungBest/etc as reactive
+  // Proxies. IDB structured-clone rejects Proxies → every round silently failed
+  // to persist. Snapshot at the IDB boundary fixes it.
+  it('persists attempt and updated item without DataCloneError', async () => {
+    const deps = await makeRealDeps(db);
+    const ctrl = createSessionController(deps);
+
+    ctrl._forceState({
+      kind: 'listening',
+      item: baseItem,
+      timbre: 'piano',
+      register: 'comfortable',
+      targetStartedAt: 0,
+      frames: [{ at_ms: 100, hz: 392, confidence: 0.95 }],
+      digit: 5,
+      digitConfidence: 0.9,
+    } as never);
+    ctrl._checkCaptureEnd();
+    await flushPromises();
+
+    expect(get(degradationState).persistenceFailing).toBe(false);
+
+    const persistedItem = await db.get('items', baseItem.id);
+    expect(persistedItem).toBeDefined();
+    expect(persistedItem!.attempts).toBe(1);
+    expect(persistedItem!.box).toBe('learning');
+
+    const persistedAttempts = await db.getAllFromIndex('attempts', 'by-session', baseSession.id);
+    expect(persistedAttempts).toHaveLength(1);
+    expect(persistedAttempts[0]!.item_id).toBe(baseItem.id);
+    expect(persistedAttempts[0]!.graded.pass).toBe(true);
+  });
+});

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -104,7 +104,9 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
 
         // Persist the attempt and update item SRS state.
         // Use at_ms from the CAPTURE_COMPLETE event as the clock source.
-        const gradedState = this.state as Extract<RoundState, { kind: 'graded' }>;
+        // $state-backed state exposes fields as reactive Proxies, which IndexedDB's
+        // structured-clone cannot serialize. Snapshot at the boundary.
+        const gradedState = $state.snapshot(this.state) as Extract<RoundState, { kind: 'graded' }>;
         const item = gradedState.item;
         const now = event.type === 'CAPTURE_COMPLETE' ? event.at_ms : Date.now();
         const pitchOk = gradedState.outcome.pitch;

--- a/apps/ear-training-station/src/lib/shell/onboarding/StepWarmupRound.svelte
+++ b/apps/ear-training-station/src/lib/shell/onboarding/StepWarmupRound.svelte
@@ -4,9 +4,10 @@
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { onMount, onDestroy } from 'svelte';
-  import { settings } from '$lib/shell/stores';
+  import { settings, allItems } from '$lib/shell/stores';
   import type { Item } from '@ear-training/core/types/domain';
   import type { SessionController } from '$lib/exercises/scale-degree';
+  import { buildInitialItems } from '@ear-training/core/seed/initial-items';
 
   let { onBack }: { onBack: () => void } = $props();
 
@@ -53,6 +54,16 @@
       await controller.next(); // completes the session since target_items === 1
     }
     const deps = await getDeps();
+    // Seed the starter curriculum for the user's first real session. The warmup round
+    // persists one item (5-C-major); without this, findDue() would return only that one
+    // item and every round would hit the same target.
+    const existing = await deps.items.listAll();
+    const existingIds = new Set(existing.map((it) => it.id));
+    const seeds = buildInitialItems({ now: Date.now() }).filter((s) => !existingIds.has(s.id));
+    if (seeds.length > 0) {
+      await deps.items.putMany(seeds);
+      allItems.set([...existing, ...seeds]);
+    }
     await deps.settings.update({ onboarded: true });
     settings.update((s) => ({ ...s, onboarded: true }));
     await goto(resolve('/scale-degree'));

--- a/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.ts
+++ b/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.ts
@@ -16,8 +16,13 @@ export async function load({ params, url }) {
     url.searchParams.get('preview') === 'mic-denied' &&
     (dev || import.meta.env.MODE === 'test');
 
-  if (session.ended_at == null && !bypassAbandon) {
-    // Refresh-abandon: roll up whatever attempts exist, mark complete.
+  // Refresh-abandon only fires on actual browser reloads (F5 / reload button) of an
+  // ongoing session. Fresh SPA navigations from the dashboard do NOT abandon — the
+  // session was just created. Detected via the Navigation Timing API.
+  const isReload = typeof performance !== 'undefined'
+    && (performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined)?.type === 'reload';
+
+  if (session.ended_at == null && isReload && !bypassAbandon) {
     const attempts = await deps.attempts.findBySession(session.id);
     const rollup = rollUpAbandonedSession(attempts);
     await deps.sessions.complete(session.id, rollup);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@vite-pwa/sveltekit':
         specifier: 1.1.0
         version: 1.1.0(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(terser@5.46.1)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(terser@5.46.1)))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(terser@5.46.1))(workbox-build@7.4.0)(workbox-window@7.4.0)
+      fake-indexeddb:
+        specifier: 6.0.0
+        version: 6.0.0
       svelte:
         specifier: 5.55.4
         version: 5.55.4(@typescript-eslint/types@8.58.2)


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant U as User
    participant D as Dashboard
    participant N as Navigation
    participant L as +page.ts load()
    participant C as Controller
    participant I as IndexedDB

    Note over U,I: Before this PR — happy path broken
    U->>D: Click "Start today's session"
    D->>I: sessions.start (ended_at:null)
    D->>N: goto /sessions/<id>
    N->>L: load()
    L-->>L: ended_at==null → abandon
    L->>I: sessions.complete
    L-->>U: render SummaryView (0 rounds)

    Note over U,I: After this PR
    U->>D: Click "Start today's session"
    D->>I: sessions.start (ended_at:null)
    D->>N: goto /sessions/<id>
    N->>L: load()
    L-->>L: not a reload → do NOT abandon
    L-->>U: render ActiveRound
    U->>C: Start round
    C->>I: $state.snapshot(item) → put/append OK
    C-->>U: FeedbackPanel
```

## Summary

Integration pass discovered via Playwright MCP walkthrough of the scale-degree happy path. Three real bugs made Plan C1 non-functional end-to-end; all tests pass after each fix.

**1. `$state.snapshot` across the IDB boundary** — Svelte 5 runes wrap `$state<RoundState>` in reactive Proxies. IndexedDB's structured-clone rejects Proxies → every round silently threw `DataCloneError`, the DegradationBanner fired `persistenceFailing: true`, and no Leitner/streak progress persisted. Existing unit tests mocked the repos so the failure never surfaced. Added a regression test that drives the controller against a real `createItemsRepo` + `fake-indexeddb`.

**2. Refresh-abandon fired on first navigation, not just reload** — `+page.ts` load() treated any navigation with `session.ended_at == null` as a refresh. The dashboard's `sessions.start → goto` was immediately completed by load(), so the session screen rendered SummaryView with 0 rounds. This was the blocker called out in the skipped `round-graded.spec.ts`. Fix: gate refresh-abandon on `performance.getEntriesByType('navigation')[0].type === 'reload'`. `session-abandon.spec.ts` updated to reload after navigation.

**3. Starter curriculum never seeded** — `buildInitialItems()` exists in core but was never called. After onboarding the DB held only the single warmup item, so every session served the same 5-C-major target. Fix: seed in the onboarding `finish()` handler with an existingIds guard (idempotent on rerun).

## Verification

- 340/340 unit tests pass
- 20/20 e2e pass (2 skipped preserved)
- Lint green, typecheck green
- Playwright MCP walkthrough: onboarding → warmup → dashboard (3 new items) → session → three rounds cycle through targets 5, 1, 3 → no DegradationBanner → reload correctly abandons

## Test plan

- [x] Vitest suite
- [x] Playwright e2e suite
- [x] Manual Playwright MCP happy path
- [x] Reload still abandons (regression direction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)