### PR TITLE
fix(audio): session-scoped AudioContext to stop Chrome 6-context leak (#104)

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -74,6 +74,11 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     #disposed = false;
     #history: VariabilityHistory = { lastTimbre: null, lastRegister: null };
     #rng: () => number = deps.rng ?? Math.random;
+    // One AudioContext per session, created lazily on the first startRound()
+    // and reused for every round. Chrome caps concurrent contexts at ~6; a
+    // fresh context per round silently exhausts the budget and breaks the
+    // pitch worklet (every round grades as pitch-fail, corrupting SRS).
+    #audioContext: AudioContext | null = null;
 
     // Persistence state — maintained across rounds
     #reviewsInBox: SvelteMap<string, number> = new SvelteMap();
@@ -196,7 +201,12 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       if (this.state.kind !== 'idle') return; // guard against double-start
       if (this.currentItem == null) return;
 
-      const ctx = deps.getAudioContext();
+      // Create the session AudioContext lazily on the first round, then reuse
+      // it for every subsequent round. Closed in dispose().
+      if (this.#audioContext == null) {
+        this.#audioContext = deps.getAudioContext();
+      }
+      const ctx = this.#audioContext;
       const stream = await deps.getMicStream();
 
       // Pick timbre and register via variability pickers (no monoculture)
@@ -334,6 +344,15 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       consecutiveNullCount.set(0);
       degradationState.update((s) => ({ ...s, kwsUnavailable: false }));
       this.#stopAudioHandles();
+      // Release the session's AudioContext so Chrome's ~6-context budget isn't
+      // consumed by stale contexts from prior sessions. close() is async but we
+      // fire-and-forget: the caller doesn't need to await disposal, and close()
+      // can reject if the context is already closed — which we don't care about.
+      if (this.#audioContext != null) {
+        const ctx = this.#audioContext;
+        this.#audioContext = null;
+        ctx.close().catch(() => { /* already closed or unsupported */ });
+      }
     }
 
     #stopAudioHandles(): void {

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -546,3 +546,80 @@ describe('SessionController — consecutiveNullCount store', () => {
     expect(get(consecutiveNullCount)).toBe(0);
   });
 });
+
+describe('SessionController — AudioContext lifecycle (GitHub #104 / Plan C2 Task 1)', () => {
+  // Build a mock AudioContext with a `close` spy so we can assert lifecycle.
+  function makeMockContext() {
+    const close = vi.fn(async () => undefined);
+    const ctx = new (class {
+      currentTime = 0;
+      sampleRate = 48000;
+      audioWorklet = { addModule: vi.fn(async () => undefined) };
+      createBuffer() { return {} as AudioBuffer; }
+      createMediaStreamSource() { return { connect: vi.fn(), disconnect: vi.fn() }; }
+      close = close;
+    })() as unknown as AudioContext;
+    return { ctx, close };
+  }
+
+  it('startRound() calls getAudioContext() at most once across multiple rounds', async () => {
+    const { ctx } = makeMockContext();
+    const getAudioContext = vi.fn(() => ctx);
+    const deps = { ...makeDeps(), getAudioContext };
+    const ctrl = createSessionController(deps);
+
+    // startRound() pulls in web-platform modules that touch browser APIs the
+    // jsdom env doesn't provide; the call will reject partway through. We only
+    // care that getAudioContext was consulted on the way in.
+    await ctrl.startRound().catch(() => {});
+
+    // Drive the controller back to idle so a second startRound() would pass
+    // its own kind-guard. _forceState bypasses the normal flow.
+    ctrl._forceState({ kind: 'idle' } as never);
+    await ctrl.startRound().catch(() => {});
+
+    // Even across two startRound attempts, only one AudioContext is created.
+    expect(getAudioContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispose() closes the cached AudioContext', async () => {
+    const { ctx, close } = makeMockContext();
+    const getAudioContext = vi.fn(() => ctx);
+    const deps = { ...makeDeps(), getAudioContext };
+    const ctrl = createSessionController(deps);
+
+    await ctrl.startRound().catch(() => {});
+    expect(getAudioContext).toHaveBeenCalled();
+
+    ctrl.dispose();
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispose() is safe when no round ever ran and no context was created', () => {
+    const { close } = makeMockContext();
+    const getAudioContext = vi.fn(() => makeMockContext().ctx);
+    const deps = { ...makeDeps(), getAudioContext };
+    const ctrl = createSessionController(deps);
+
+    // No startRound() → no context created → dispose() must not try to close
+    // anything and must not throw.
+    expect(() => ctrl.dispose()).not.toThrow();
+    expect(getAudioContext).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('dispose() is idempotent and only closes the context once', async () => {
+    const { ctx, close } = makeMockContext();
+    const getAudioContext = vi.fn(() => ctx);
+    const deps = { ...makeDeps(), getAudioContext };
+    const ctrl = createSessionController(deps);
+
+    await ctrl.startRound().catch(() => {});
+
+    ctrl.dispose();
+    ctrl.dispose();
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ear-training-station/src/lib/shell/onboarding/StepWarmupRound.svelte
+++ b/apps/ear-training-station/src/lib/shell/onboarding/StepWarmupRound.svelte
@@ -27,6 +27,11 @@
 
   let controller = $state<SessionController | null>(null);
 
+  // Session-scoped AudioContext: created once when the warmup session begins,
+  // reused if the factory is called again, closed on controller.dispose().
+  // See GitHub #104 / Plan C2 Task 1 for rationale.
+  let sessionAudioContext: AudioContext | null = null;
+
   onMount(async () => {
     const deps = await getDeps();
     const id = crypto.randomUUID();
@@ -38,7 +43,10 @@
       attemptsRepo: deps.attempts,
       sessionsRepo: deps.sessions,
       settingsRepo: deps.settings,
-      getAudioContext: () => new AudioContext(),
+      getAudioContext: () => {
+        if (sessionAudioContext == null) sessionAudioContext = new AudioContext();
+        return sessionAudioContext;
+      },
       getMicStream: async () => {
         const { requestMicStream } = await import('@ear-training/web-platform/mic/permission');
         const handle = await requestMicStream();

--- a/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte
+++ b/apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte
@@ -41,6 +41,13 @@
       return;
     }
 
+    // Session-scoped AudioContext: created once when the session begins, reused
+    // for every round, closed on controller.dispose(). Chrome caps concurrent
+    // contexts at ~6; a fresh context per round silently exhausts the budget
+    // and breaks the pitch worklet (every round then grades as pitch-fail,
+    // corrupting SRS). See GitHub #104 / Plan C2 Task 1.
+    let sessionAudioContext: AudioContext | null = null;
+
     controller = createSessionController({
       session: data.session,
       firstItem: items[0],
@@ -48,7 +55,10 @@
       attemptsRepo: deps.attempts,
       sessionsRepo: deps.sessions,
       settingsRepo: deps.settings,
-      getAudioContext: () => new AudioContext(),
+      getAudioContext: () => {
+        if (sessionAudioContext == null) sessionAudioContext = new AudioContext();
+        return sessionAudioContext;
+      },
       getMicStream: async () => {
         const { requestMicStream } = await import('@ear-training/web-platform/mic/permission');
         const handle = await requestMicStream();


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
  participant User
  participant Page as +page.svelte
  participant Ctrl as SessionController
  participant AC as AudioContext

  Note over Page,AC: BEFORE — every startRound() creates a new AudioContext.<br/>After ~6 rounds Chrome silently refuses new contexts, the<br/>pitch worklet never fires, and every round grades pitch-fail.

  User->>Page: enter session
  Page->>Ctrl: createSessionController({ getAudioContext: () => new AudioContext() })

  loop each round
    User->>Ctrl: startRound()
    Ctrl->>Page: deps.getAudioContext()
    Page->>AC: new AudioContext()  [leak]
  end

  Note over Page,AC: AFTER — one AudioContext per session, reused, closed on dispose.

  User->>Page: enter session
  Page->>Ctrl: createSessionController({ getAudioContext: cachedFactory })

  loop each round
    User->>Ctrl: startRound()
    alt first call
      Ctrl->>Page: deps.getAudioContext()
      Page->>AC: new AudioContext()
    else subsequent calls
      Ctrl-->>Ctrl: return #audioContext (cached)
    end
  end

  User->>Page: leave session
  Page->>Ctrl: dispose()
  Ctrl->>AC: close()
```

## Summary

Fixes #104.

`getAudioContext: () => new AudioContext()` was called on every `startRound()`. Chrome caps concurrent AudioContexts at ~6; past that the worklet never fires, no pitch frames are produced, every round grades as pitch-fail, and SRS data is silently and durably corrupted.

- Call sites (`+page.svelte`, `StepWarmupRound.svelte`) own the single instance in a closure — the factory returns the cached one on subsequent calls, signalling session scope at the boundary.
- Controller caches defensively on first `startRound()` and calls `audioContext.close()` in `dispose()` (fire-and-forget; safe if already closed).
- Four new unit tests cover: single-creation across rounds, dispose closes, no-round-ever-ran is safe, dispose idempotency.

## Files changed

- `apps/ear-training-station/src/routes/scale-degree/sessions/[id]/+page.svelte` — factory caches session-scoped instance
- `apps/ear-training-station/src/lib/shell/onboarding/StepWarmupRound.svelte` — same fix for onboarding warmup
- `apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts` — defensive cache + `dispose()` closes the context
- `apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts` — four new lifecycle tests

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` — 344 tests pass (up from 340, four new AudioContext lifecycle tests)
- [x] `pnpm run build` — clean prod bundle
- [x] `pnpm run lint` — clean
- [ ] Manual: open the app, start and complete 8+ rounds in one session, confirm the pitch detector keeps producing frames past round 6 (behavior that would fail on `main`)
- [ ] Manual: navigate away mid-session, confirm no "AudioContext was not allowed to start" or "maximum number of contexts" warnings in DevTools

## Concerns / notes

- The factory contract (`getAudioContext: () => AudioContext`) is preserved. Callers now return a cached instance; the controller caches defensively. This keeps the interface shape so tests, e2e fixtures, and future callers don't need to change — and preserves the lazy-creation property (no context is allocated if the user never actually starts a round).
- `AudioContext.close()` is async and fire-and-forget in `dispose()`. If the controller is re-disposed or the context is already closed, the `.catch()` swallows the error — we don't need to surface it to the user.
- `pnpm run check` (svelte-check) reports 40 pre-existing errors on `main` that this PR does not touch. Per CLAUDE.md, `pnpm run typecheck` is authoritative and it passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)