### PR TITLE
fix(session): surface startRound() errors so clicks stop silently stalling (C2/T3, #106)

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.svelte
@@ -101,6 +101,15 @@
     startError = null;
     try {
       await controller.startRound();
+      // Clear any stale mic-permission flag from a prior failed attempt. Without
+      // this, a user who denies mic access, grants it in browser settings, and
+      // then successfully starts a round would still see the "Microphone access
+      // blocked" banner for the rest of the session (until page reload). The
+      // update is conditional so we don't churn subscribers when the flag is
+      // already false (the common path).
+      degradationState.update((s) =>
+        s.micPermissionDenied ? { ...s, micPermissionDenied: false } : s,
+      );
     } catch (err) {
       startError = describeStartError(err);
       if (isMicError(err)) {

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.svelte
@@ -5,8 +5,16 @@
   import PitchTrace from './PitchTrace.svelte';
   import { buildCadence } from '@ear-training/core/audio/cadence-structure';
   import type { ChordEvent } from '@ear-training/core/audio/cadence-structure';
+  import { degradationState } from '$lib/shell/stores';
 
   let { controller }: { controller: SessionController } = $props();
+
+  // Local error state for startRound() failures. Cleared on the next attempt so
+  // the user can retry by clicking the button again without a separate reset UI.
+  // See GitHub #106 / Plan C2 Task 3 — previously startRound() rejections were
+  // silently swallowed by the Svelte event handler, stranding the user on an
+  // idle-looking UI with no feedback.
+  let startError = $state<string | null>(null);
 
   const cadence = $derived<ChordEvent[]>(
     controller.currentItem ? buildCadence(controller.currentItem.key) : [],
@@ -42,8 +50,61 @@
 
   const traceDegree = $derived(controller.currentItem?.degree ?? 1);
 
+  /**
+   * True iff the rejection came from `getUserMedia` / mic-unavailable paths.
+   * Distinguishing this lets us both show the user the actionable mic message
+   * AND flip `degradationState.micLost` so the persistent DegradationBanner
+   * mirrors the condition across navigations.
+   *
+   * DOMException names from `navigator.mediaDevices.getUserMedia`:
+   * - `NotAllowedError` — user or policy denied permission
+   * - `PermissionDeniedError` — legacy alias seen in older Chromium
+   * - `NotFoundError` — no input device detected
+   * - `NotReadableError` — hardware in use by another app / locked
+   *
+   * `code: 'unavailable'` is the marker attached by
+   * `requestMicStream()` when the Microphone API is absent entirely
+   * (older Safari, insecure context, etc.).
+   */
+  function isMicError(err: unknown): boolean {
+    const name = err instanceof Error ? err.name : '';
+    const code = (err as { code?: string } | null)?.code;
+    return (
+      name === 'NotAllowedError' ||
+      name === 'PermissionDeniedError' ||
+      name === 'NotFoundError' ||
+      name === 'NotReadableError' ||
+      code === 'unavailable'
+    );
+  }
+
+  /**
+   * Classify a `startRound()` rejection into user-visible copy. Mic failures
+   * get a specific, actionable message; other failures (AudioContext creation,
+   * worklet load, IDB read) fall through to a generic message — we don't want
+   * to invent specific guidance the user can't act on.
+   */
+  function describeStartError(err: unknown): string {
+    if (isMicError(err)) {
+      return 'Microphone access is required to practice. Enable mic access in your browser settings and try again.';
+    }
+    return 'Could not start the round. Please try again.';
+  }
+
   async function start() {
-    await controller.startRound();
+    // Clear any prior error so a retry shows a fresh attempt.
+    startError = null;
+    try {
+      await controller.startRound();
+    } catch (err) {
+      startError = describeStartError(err);
+      if (isMicError(err)) {
+        degradationState.update((s) => ({ ...s, micLost: true }));
+      }
+      // Diagnostics: preserves the original error shape for debugging without
+      // exposing internals to the user.
+      console.error('ActiveRound: startRound() failed', err);
+    }
   }
 </script>
 
@@ -77,6 +138,9 @@
       <button type="button" class="start" onclick={start}>Start round</button>
     </div>
   {/if}
+  {#if startError}
+    <p class="start-error" role="alert" aria-live="polite">{startError}</p>
+  {/if}
 </section>
 
 <style>
@@ -95,5 +159,12 @@
     border: 1px solid var(--cyan); background: transparent;
     color: var(--cyan); font-size: 12px;
     cursor: pointer;
+  }
+  .start-error {
+    text-align: center;
+    font-size: 11px;
+    color: var(--red);
+    margin: 12px auto 0;
+    max-width: 400px;
   }
 </style>

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.svelte
@@ -53,8 +53,13 @@
   /**
    * True iff the rejection came from `getUserMedia` / mic-unavailable paths.
    * Distinguishing this lets us both show the user the actionable mic message
-   * AND flip `degradationState.micLost` so the persistent DegradationBanner
-   * mirrors the condition across navigations.
+   * AND flip `degradationState.micPermissionDenied` so the persistent
+   * DegradationBanner mirrors the condition across navigations.
+   *
+   * NB: We flip `micPermissionDenied`, NOT `micLost`. The mic was never
+   * connected in the first place — "reconnect to continue" copy would be
+   * confusing. `micLost` is reserved for a future runtime-disconnect path
+   * where the mic was working and then dropped.
    *
    * DOMException names from `navigator.mediaDevices.getUserMedia`:
    * - `NotAllowedError` — user or policy denied permission
@@ -99,7 +104,7 @@
     } catch (err) {
       startError = describeStartError(err);
       if (isMicError(err)) {
-        degradationState.update((s) => ({ ...s, micLost: true }));
+        degradationState.update((s) => ({ ...s, micPermissionDenied: true }));
       }
       // Diagnostics: preserves the original error shape for debugging without
       // exposing internals to the user.

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.test.ts
@@ -41,6 +41,7 @@ describe('ActiveRound — startRound() error surfacing (GitHub #106 / Plan C2 Ta
     degradationState.set({
       kwsUnavailable: false,
       persistenceFailing: false,
+      micPermissionDenied: false,
       micLost: false,
     });
   });
@@ -64,8 +65,11 @@ describe('ActiveRound — startRound() error surfacing (GitHub #106 / Plan C2 Ta
     // access). If this string drifts without thought, the task's AC drifts.
     expect(screen.getByRole('alert')).toHaveTextContent(/microphone access is required/i);
     // The persistent banner mirrors the condition so the user sees context even
-    // if they navigate away and come back.
-    expect(get(degradationState).micLost).toBe(true);
+    // if they navigate away and come back. We flip `micPermissionDenied`, NOT
+    // `micLost` — "disconnected, reconnect" copy is wrong when the mic was
+    // never connected in the first place.
+    expect(get(degradationState).micPermissionDenied).toBe(true);
+    expect(get(degradationState).micLost).toBe(false);
   });
 
   it('renders a generic message when startRound() rejects with a non-mic error', async () => {
@@ -80,8 +84,9 @@ describe('ActiveRound — startRound() error surfacing (GitHub #106 / Plan C2 Ta
     await userEvent.click(screen.getByRole('button', { name: /start round/i }));
 
     expect(screen.getByRole('alert')).toHaveTextContent(/could not start the round/i);
-    // Non-mic errors must NOT flip micLost — that would mislead the user into
-    // thinking the mic is the problem when it isn't.
+    // Non-mic errors must NOT flip either mic flag — that would mislead the
+    // user into thinking the mic is the problem when it isn't.
+    expect(get(degradationState).micPermissionDenied).toBe(false);
     expect(get(degradationState).micLost).toBe(false);
   });
 
@@ -151,6 +156,7 @@ describe('ActiveRound — startRound() error surfacing (GitHub #106 / Plan C2 Ta
     await userEvent.click(screen.getByRole('button', { name: /start round/i }));
 
     expect(screen.getByRole('alert')).toHaveTextContent(/microphone access is required/i);
-    expect(get(degradationState).micLost).toBe(true);
+    expect(get(degradationState).micPermissionDenied).toBe(true);
+    expect(get(degradationState).micLost).toBe(false);
   });
 });

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.test.ts
@@ -1,23 +1,156 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { get } from 'svelte/store';
 import ActiveRound from './ActiveRound.svelte';
+import { degradationState } from '$lib/shell/stores';
 
-const stubController = {
+const baseControllerShape = {
   state: { kind: 'idle' as const },
   session: { id: 's' },
   currentItem: { id: 'i', degree: 5, key: { tonic: 'C', quality: 'major' } },
   capturedAudio: null,
   targetAudio: null,
-  startRound: async () => {},
   cancelRound: () => {},
   next: async () => {},
   dispose: () => {},
   _forceState: () => {},
+};
+
+const stubController = {
+  ...baseControllerShape,
+  startRound: async () => {},
 } as never;
 
 describe('ActiveRound', () => {
   it('renders a Start Round button in idle state', () => {
     render(ActiveRound, { controller: stubController });
     expect(screen.getByRole('button', { name: /start round/i })).toBeInTheDocument();
+  });
+});
+
+describe('ActiveRound — startRound() error surfacing (GitHub #106 / Plan C2 Task 3)', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // The error handler logs by design for diagnostics; silence it in tests so
+    // the terminal output isn't noisy.
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Reset degradation store so the mic-error assertion is independent of
+    // test order.
+    degradationState.set({
+      kwsUnavailable: false,
+      persistenceFailing: false,
+      micLost: false,
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders an actionable mic-permission message when startRound() rejects with NotAllowedError', async () => {
+    const err = Object.assign(new Error('Permission denied'), { name: 'NotAllowedError' });
+    const controller = {
+      ...baseControllerShape,
+      startRound: vi.fn(async () => { throw err; }),
+    } as never;
+
+    render(ActiveRound, { controller });
+
+    await userEvent.click(screen.getByRole('button', { name: /start round/i }));
+
+    // The alert copy must point the user to the concrete action (re-enable mic
+    // access). If this string drifts without thought, the task's AC drifts.
+    expect(screen.getByRole('alert')).toHaveTextContent(/microphone access is required/i);
+    // The persistent banner mirrors the condition so the user sees context even
+    // if they navigate away and come back.
+    expect(get(degradationState).micLost).toBe(true);
+  });
+
+  it('renders a generic message when startRound() rejects with a non-mic error', async () => {
+    const err = new Error('AudioContext construction failed');
+    const controller = {
+      ...baseControllerShape,
+      startRound: vi.fn(async () => { throw err; }),
+    } as never;
+
+    render(ActiveRound, { controller });
+
+    await userEvent.click(screen.getByRole('button', { name: /start round/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not start the round/i);
+    // Non-mic errors must NOT flip micLost — that would mislead the user into
+    // thinking the mic is the problem when it isn't.
+    expect(get(degradationState).micLost).toBe(false);
+  });
+
+  it('does not render an error message when startRound() resolves successfully', async () => {
+    const controller = {
+      ...baseControllerShape,
+      startRound: vi.fn(async () => { /* resolves */ }),
+    } as never;
+
+    render(ActiveRound, { controller });
+
+    await userEvent.click(screen.getByRole('button', { name: /start round/i }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('still renders the Start round button after a failure so the user can retry', async () => {
+    const controller = {
+      ...baseControllerShape,
+      startRound: vi.fn(async () => { throw new Error('boom'); }),
+    } as never;
+
+    render(ActiveRound, { controller });
+
+    const button = screen.getByRole('button', { name: /start round/i });
+    await userEvent.click(button);
+
+    // Button stays visible — the controller's state is still 'idle' so
+    // the template keeps rendering it, and the user can click again.
+    expect(screen.getByRole('button', { name: /start round/i })).toBeInTheDocument();
+  });
+
+  it('clears the error on the next click so a retry does not show stale copy', async () => {
+    // First call throws, second resolves — proves the error state is reset
+    // at the top of start() and not sticky after success.
+    let attempt = 0;
+    const controller = {
+      ...baseControllerShape,
+      startRound: vi.fn(async () => {
+        attempt++;
+        if (attempt === 1) throw new Error('transient');
+      }),
+    } as never;
+
+    render(ActiveRound, { controller });
+
+    const button = screen.getByRole('button', { name: /start round/i });
+    await userEvent.click(button);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    await userEvent.click(button);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('matches mic errors by DOMException code "unavailable" (no Permissions API)', async () => {
+    // `requestMicStream` throws an Error with `code: 'unavailable'` when the
+    // browser lacks the API entirely (e.g. older Safari, insecure context).
+    // The UI must treat this as a mic error, not a generic failure.
+    const err = Object.assign(new Error('Microphone API unavailable in this browser'), { code: 'unavailable' });
+    const controller = {
+      ...baseControllerShape,
+      startRound: vi.fn(async () => { throw err; }),
+    } as never;
+
+    render(ActiveRound, { controller });
+
+    await userEvent.click(screen.getByRole('button', { name: /start round/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/microphone access is required/i);
+    expect(get(degradationState).micLost).toBe(true);
   });
 });

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.test.ts
@@ -141,6 +141,33 @@ describe('ActiveRound — startRound() error surfacing (GitHub #106 / Plan C2 Ta
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
+  it('clears micPermissionDenied after a successful retry (user granted access in browser settings)', async () => {
+    // Regression guard for the review finding on PR #126: previously the catch
+    // block flipped `micPermissionDenied` to true but nothing ever flipped it
+    // back. Realistic flow: user denies mic → banner appears → user grants in
+    // browser settings → clicks Start again → round starts — but the banner
+    // stayed on screen for the rest of the session. The success path must
+    // clear the stale flag so the persistent banner matches reality.
+    let attempt = 0;
+    const micErr = Object.assign(new Error('Permission denied'), { name: 'NotAllowedError' });
+    const controller = {
+      ...baseControllerShape,
+      startRound: vi.fn(async () => {
+        attempt++;
+        if (attempt === 1) throw micErr;
+      }),
+    } as never;
+
+    render(ActiveRound, { controller });
+
+    const button = screen.getByRole('button', { name: /start round/i });
+    await userEvent.click(button);
+    expect(get(degradationState).micPermissionDenied).toBe(true);
+
+    await userEvent.click(button);
+    expect(get(degradationState).micPermissionDenied).toBe(false);
+  });
+
   it('matches mic errors by DOMException code "unavailable" (no Permissions API)', async () => {
     // `requestMicStream` throws an Error with `code: 'unavailable'` when the
     // browser lacks the API entirely (e.g. older Safari, insecure context).

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.integration.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.integration.test.ts
@@ -64,7 +64,12 @@ describe('SessionController — persistence against real IndexedDB', () => {
     indexedDB = new IDBFactory();
     db = await openEarTrainingDB('ear-training-test');
     allItems.set([]);
-    degradationState.set({ kwsUnavailable: false, persistenceFailing: false, micLost: false });
+    degradationState.set({
+      kwsUnavailable: false,
+      persistenceFailing: false,
+      micPermissionDenied: false,
+      micLost: false,
+    });
   });
 
   // Regression: $state-backed RoundState exposes item/sungBest/etc as reactive

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -623,3 +623,60 @@ describe('SessionController — AudioContext lifecycle (GitHub #104 / Plan C2 Ta
     expect(close).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('SessionController — startRound() rejection propagation (GitHub #106 / Plan C2 Task 3)', () => {
+  // The controller does not wrap its own async failures — it propagates them so
+  // the caller (ActiveRound.svelte) can surface a user-visible error. These
+  // tests pin that contract: without propagation, the UI can't show an error,
+  // and the failure is silent (which is exactly what #106 fixed at the UI seam).
+
+  it('startRound() rejects when getMicStream() rejects with a permission error', async () => {
+    const deps = makeDeps();
+    const micError = Object.assign(new Error('Permission denied'), { name: 'NotAllowedError' });
+    deps.getMicStream = vi.fn(async () => { throw micError; });
+    const ctrl = createSessionController(deps);
+
+    await expect(ctrl.startRound()).rejects.toBe(micError);
+  });
+
+  it('startRound() rejects when getAudioContext() throws synchronously', async () => {
+    const deps = makeDeps();
+    const audioError = new Error('AudioContext creation failed');
+    deps.getAudioContext = vi.fn(() => { throw audioError; });
+    const ctrl = createSessionController(deps);
+
+    await expect(ctrl.startRound()).rejects.toBe(audioError);
+  });
+
+  it('getMicStream() is invoked as part of startRound(), wiring up the mic-error path', async () => {
+    const deps = makeDeps();
+    const getMicStream = vi.fn(async () => ({} as MediaStream));
+    deps.getMicStream = getMicStream;
+    const ctrl = createSessionController(deps);
+
+    // startRound() pulls in web-platform modules that require real browser APIs
+    // (AudioWorklet, etc.) which jsdom doesn't provide, so the promise rejects
+    // partway through. We only care that getMicStream was consulted — that
+    // proves mic-permission errors would propagate, since that's where the
+    // NotAllowedError surfaces in production.
+    await ctrl.startRound().catch(() => {});
+
+    expect(getMicStream).toHaveBeenCalled();
+  });
+
+  it('state remains idle when startRound() rejects on getMicStream()', async () => {
+    // Regression pin: before #106 the UI silently stayed in idle with no
+    // feedback. The fix is at the call site (ActiveRound.svelte), so the
+    // controller-level contract we rely on is that the state does NOT
+    // advance past idle when the mic acquisition step fails.
+    const deps = makeDeps();
+    deps.getMicStream = vi.fn(async () => {
+      throw Object.assign(new Error('Permission denied'), { name: 'NotAllowedError' });
+    });
+    const ctrl = createSessionController(deps);
+
+    await ctrl.startRound().catch(() => {});
+
+    expect(ctrl.state.kind).toBe('idle');
+  });
+});

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -443,7 +443,12 @@ describe('SessionController — persistence failure counter consistency', () => 
   }
 
   beforeEach(() => {
-    degradationState.set({ kwsUnavailable: false, persistenceFailing: false, micLost: false });
+    degradationState.set({
+      kwsUnavailable: false,
+      persistenceFailing: false,
+      micPermissionDenied: false,
+      micLost: false,
+    });
   });
 
   it('sets degradationState.persistenceFailing when itemsRepo.put rejects', async () => {

--- a/apps/ear-training-station/src/lib/shell/DegradationBanner.svelte
+++ b/apps/ear-training-station/src/lib/shell/DegradationBanner.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
   import { degradationState } from './stores';
 
+  // Copy is scenario-specific so the user sees actionable guidance:
+  // - `micPermissionDenied` — the user never granted access; telling them to
+  //   "reconnect" a device that was never connected would be misleading.
+  // - `micLost` — the mic was working and then dropped mid-session; reconnect
+  //   is the right action. (Reserved for a future runtime-disconnect path.)
+  // If both flags happen to be true, show permission-denied first because that
+  // is the blocking condition the user must resolve before reconnecting can
+  // matter.
   const messages = $derived([
     $degradationState.kwsUnavailable && 'Speech recognition unavailable — you can still sing the note.',
     $degradationState.persistenceFailing && 'Saving locally failed — progress may not persist.',
+    $degradationState.micPermissionDenied && 'Microphone access blocked — enable mic access in your browser settings.',
     $degradationState.micLost && 'Microphone disconnected — reconnect to continue.',
   ].filter(Boolean) as string[]);
 </script>

--- a/apps/ear-training-station/src/lib/shell/DegradationBanner.test.ts
+++ b/apps/ear-training-station/src/lib/shell/DegradationBanner.test.ts
@@ -5,7 +5,12 @@ import { degradationState } from './stores';
 
 describe('DegradationBanner', () => {
   beforeEach(() => {
-    degradationState.set({ kwsUnavailable: false, persistenceFailing: false, micLost: false });
+    degradationState.set({
+      kwsUnavailable: false,
+      persistenceFailing: false,
+      micPermissionDenied: false,
+      micLost: false,
+    });
   });
 
   it('renders nothing when no degradation is active', () => {
@@ -22,9 +27,47 @@ describe('DegradationBanner', () => {
   it('lists multiple active signals', async () => {
     render(DegradationBanner);
     await act(() =>
-      degradationState.set({ kwsUnavailable: true, persistenceFailing: true, micLost: false }),
+      degradationState.set({
+        kwsUnavailable: true,
+        persistenceFailing: true,
+        micPermissionDenied: false,
+        micLost: false,
+      }),
     );
     expect(screen.getByText(/speech recognition unavailable/i)).toBeInTheDocument();
     expect(screen.getByText(/saving locally failed/i)).toBeInTheDocument();
+  });
+
+  // GitHub #106 follow-up / Plan C2 Task 3 code review: `micPermissionDenied`
+  // and `micLost` are distinct states — the first is "never granted access",
+  // the second is "mic dropped mid-session". Copy must not conflate them.
+  it('renders permission-denied copy, NOT the reconnect copy, for micPermissionDenied', async () => {
+    render(DegradationBanner);
+    await act(() =>
+      degradationState.set({
+        kwsUnavailable: false,
+        persistenceFailing: false,
+        micPermissionDenied: true,
+        micLost: false,
+      }),
+    );
+    expect(screen.getByText(/microphone access blocked/i)).toBeInTheDocument();
+    // The older "reconnect" copy must NOT appear — that message is for a
+    // device that was connected and then dropped, which did not happen here.
+    expect(screen.queryByText(/microphone disconnected/i)).not.toBeInTheDocument();
+  });
+
+  it('renders disconnect copy for micLost (runtime drop scenario)', async () => {
+    render(DegradationBanner);
+    await act(() =>
+      degradationState.set({
+        kwsUnavailable: false,
+        persistenceFailing: false,
+        micPermissionDenied: false,
+        micLost: true,
+      }),
+    );
+    expect(screen.getByText(/microphone disconnected/i)).toBeInTheDocument();
+    expect(screen.queryByText(/microphone access blocked/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/ear-training-station/src/lib/shell/stores.ts
+++ b/apps/ear-training-station/src/lib/shell/stores.ts
@@ -9,11 +9,28 @@ export const allSessions = writable<Session[]>([]);
 export interface DegradationState {
   kwsUnavailable: boolean;
   persistenceFailing: boolean;
+  /**
+   * `micPermissionDenied` — user never granted mic access (or the API is
+   * unavailable entirely). Distinct from `micLost`: the device was never
+   * connected, so "reconnect" copy would be misleading. Set by the startRound
+   * catch in `ActiveRound.svelte` when the rejection matches a permission or
+   * API-availability error.
+   *
+   * `micLost` — the mic was working and then dropped mid-session (runtime
+   * disconnect). Reserved for a future runtime-disconnect path; not currently
+   * set by any production code.
+   *
+   * Splitting these flags lets `DegradationBanner` render copy appropriate to
+   * each scenario instead of a single ambiguous "reconnect" message. See
+   * GitHub #106 follow-up / Plan C2 Task 3 code review.
+   */
+  micPermissionDenied: boolean;
   micLost: boolean;
 }
 export const degradationState = writable<DegradationState>({
   kwsUnavailable: false,
   persistenceFailing: false,
+  micPermissionDenied: false,
   micLost: false,
 });
 export const consecutiveNullCount = writable(0);

--- a/apps/ear-training-station/tests/shell/hydrate-error.integration.test.ts
+++ b/apps/ear-training-station/tests/shell/hydrate-error.integration.test.ts
@@ -50,6 +50,7 @@ function resetDegradation(): void {
   degradationState.set({
     kwsUnavailable: false,
     persistenceFailing: false,
+    micPermissionDenied: false,
     micLost: false,
   });
 }
@@ -141,6 +142,7 @@ describe('layout hydration — IDB-unavailable error path', () => {
     freshDegradation.set({
       kwsUnavailable: false,
       persistenceFailing: false,
+      micPermissionDenied: false,
       micLost: false,
     });
 


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    Click[User clicks &quot;Start round&quot;] --> Start["ActiveRound.start()"]
    Start --> Clear[startError = null]
    Clear --> Call[await controller.startRound]
    Call -->|resolves| Ok[Round runs normally]
    Call -->|rejects| Catch[catch]
    Catch --> Classify{isMicError?}
    Classify -->|yes| MicMsg["startError = mic message<br/>degradationState.micLost = true"]
    Classify -->|no| Generic[startError = generic message]
    MicMsg --> Log[console.error with original]
    Generic --> Log
    Log --> Render["&lt;p role=alert&gt; renders"]
    Render --> Retry[User re-clicks → start clears error]
```

## Summary

- **Problem (GitHub #106 / Plan C2 Task 3):** `ActiveRound.svelte` called `await controller.startRound()` with no try/catch, so mic-permission denials, `AudioContext` creation failures, and worklet-load errors were swallowed by Svelte's event handler. Clicks on *Start round* produced no UI change, no error, no retry prompt — the user was silently stranded on an idle-looking screen.
- **Fix:** Wrap the call site in `ActiveRound.svelte` with classification + user-visible copy. Mic errors (`NotAllowedError` / `NotFoundError` / `NotReadableError` / `PermissionDeniedError` / `code: 'unavailable'`) surface an actionable mic-access message and flip `degradationState.micLost` so the persistent `DegradationBanner` mirrors the condition. Other failures fall through to a generic message — we don't invent guidance the user can't act on.
- **Retry affordance:** Re-clicking *Start round* clears the error at the top of `start()`, so the user retries without any separate reset UI. Controller internals untouched (per task scope).

## What changed

- `apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.svelte`
  - Import `degradationState` from `$lib/shell/stores`.
  - Add local `$state<string | null>` `startError` for inline error copy.
  - Add `isMicError(err)` predicate (DOMException name + `code: 'unavailable'`) and `describeStartError(err)` classifier.
  - Wrap `await controller.startRound()` in try/catch; set `startError`, flip `degradationState.micLost` for mic errors, log to `console.error` for diagnostics.
  - Render the alert as `<p class=&quot;start-error&quot; role=&quot;alert&quot; aria-live=&quot;polite&quot;>` — placed *outside* the idle-only block so the error still shows even if a deeper pipeline failure leaves the controller past idle. Styled in red to match the dark-app aesthetic.
- `apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.test.ts`
  - 6 new tests: mic error shows actionable copy + flips `micLost`; non-mic error shows generic copy + leaves `micLost` false; happy path renders no alert; Start button stays visible after failure; retry clears the error; `code: 'unavailable'` is classified as a mic error.
- `apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts`
  - 4 new tests pinning the controller's propagation contract (the call-site fix only works if the controller doesn't swallow): `startRound()` rejects on `getMicStream` rejection; on `getAudioContext` throwing synchronously; `getMicStream` is invoked during `startRound`; state remains `idle` when `getMicStream` rejects.

## Test plan

- [x] `pnpm run test` — 358/358 pass (up from 348: +6 ActiveRound, +4 session-controller)
- [x] `pnpm run typecheck` — all 4 packages clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run build` — production build succeeds, PWA generates
- [x] Manual: read the new code paths — no secret exposure, no console.error noise in happy path

## Out of scope

- No retry logic (per task scope — a clear error message is MVP). Users retry by clicking *Start round* again or reloading.
- `startRound()` internals untouched — the fix is at the call site as specified.
- `FeedbackPanel.onNext` path already has try/catch; left alone.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)