### PR TITLE
feat(session): wire selectNextItem() into controller.next() (C2/T5, #113)

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -12,6 +12,8 @@ import type { RecorderHandle } from '@ear-training/web-platform/mic/recorder';
 import { gradeListeningState } from '@ear-training/core/round/grade-listening';
 import { pickTimbre, pickRegister, type VariabilityHistory, type TimbreId } from '@ear-training/core/variability/pickers';
 import { availableRegisters } from '@ear-training/core/scheduler/register-gating';
+import { selectNextItem } from '@ear-training/core/scheduler/selection';
+import type { RoundHistoryEntry } from '@ear-training/core/scheduler/interleaving';
 import { buildAttemptPersistence } from '@ear-training/core/round/persistence';
 import { nextBoxOnPass, nextBoxOnMiss } from '@ear-training/core/srs/leitner';
 import { SvelteMap } from 'svelte/reactivity';
@@ -56,6 +58,9 @@ export interface SessionController {
   /** @internal — test hook: read the current running pitch/label pass counters
    *  and roundIndex to verify consistency after persistence failures */
   _getRunningCounters(): { pitch: number; label: number; roundIndex: number };
+  /** @internal — test hook: seed the scheduler's round history (interleaving state)
+   *  so anti-repeat behavior can be exercised without going through full dispatch. */
+  _seedRoundHistory(entries: ReadonlyArray<RoundHistoryEntry>): void;
 }
 
 export function createSessionController(deps: SessionControllerDeps): SessionController {
@@ -73,6 +78,10 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     #captureEndTimer: number | null = null;
     #disposed = false;
     #history: VariabilityHistory = { lastTimbre: null, lastRegister: null };
+    // Round-history for the Leitner + interleaving scheduler. Populated on
+    // each successful graded transition so selectNextItem() can enforce
+    // "no same degree back-to-back" + "no same key for >3 consecutive rounds".
+    #roundHistory: RoundHistoryEntry[] = [];
     #rng: () => number = deps.rng ?? Math.random;
     // One AudioContext per session, created lazily on the first startRound()
     // and reused for every round. Chrome caps concurrent contexts at ~6; a
@@ -165,6 +174,13 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
           this.#roundIndex++;
           if (pitchOk) this.#pitchPasses++;
           if (labelOk) this.#labelPasses++;
+          // Record the completed round so the scheduler can enforce
+          // interleaving (no same-degree back-to-back, no >3 same-key streak).
+          this.#roundHistory.push({
+            itemId: item.id,
+            degree: item.degree,
+            key: item.key,
+          });
         } catch (e) {
           // Persistence failed — leave counters at pre-round values so controller
           // state stays consistent with the DB. Surface the failure to the shell banner.
@@ -310,10 +326,15 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
         return;
       }
 
-      // More items due — advance.
-      const dueNow = await deps.itemsRepo.findDue(Date.now());
-      const justPlayed = this.currentItem?.id;
-      const next = dueNow.find((i) => i.id !== justPlayed) ?? dueNow[0] ?? null;
+      // More items due — advance. Use the Leitner + interleaving scheduler
+      // (`selectNextItem`) so weak/overdue items are prioritized AND the
+      // "no same-degree back-to-back" + "no >3 same-key streak" constraints
+      // from the spec §5.2 are honored. The scheduler handles its own due-
+      // weighting internally via the item's `due_at`; pass `listAll()` so
+      // the mastered-warmup pool is visible too.
+      const now = Date.now();
+      const allItemsForScheduler = await deps.itemsRepo.listAll();
+      const next = selectNextItem(allItemsForScheduler, this.#roundHistory, now, this.#rng);
       if (next == null) {
         // Unusual: target_items says more to go but the queue is empty. Persist completion anyway.
         await deps.sessionsRepo.complete(sessionRow.id, {
@@ -407,6 +428,11 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     _getRunningCounters(): { pitch: number; label: number; roundIndex: number } {
       if (import.meta.env.MODE === 'production') return { pitch: 0, label: 0, roundIndex: 0 };
       return { pitch: this.#pitchPasses, label: this.#labelPasses, roundIndex: this.#roundIndex };
+    }
+
+    _seedRoundHistory(entries: ReadonlyArray<RoundHistoryEntry>): void {
+      if (import.meta.env.MODE === 'production') return;
+      this.#roundHistory = [...entries];
     }
   }
 

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -186,18 +186,21 @@ describe('SessionController — next()', () => {
     expect(ctrl.state.kind).toBe('idle');
   });
 
-  it('advances to idle with the next due item when more rounds remain', async () => {
+  it('advances to idle with the next item when more rounds remain', async () => {
     const nextItem: Item = { ...baseItem, id: '1-C-major', degree: 1 };
     const deps = makeDeps();
-    // Fixture order matters: baseItem (the just-played item) is first in the
-    // due queue so `dueNow[0]` would return it without the anti-repeat filter.
-    // The filter must skip baseItem and return nextItem.
-    deps.itemsRepo.findDue = vi.fn(async () => [baseItem, nextItem]);
+    // selectNextItem() takes listAll() + roundHistory. With baseItem (degree 5)
+    // in the just-played history, it is blocked by the same-degree back-to-back
+    // rule and nextItem (degree 1) must be chosen.
+    deps.itemsRepo.listAll = vi.fn(async () => [baseItem, nextItem]);
     // Session with 1/30 items completed so far
     const session: Session = { ...baseSession, completed_items: 1, target_items: 30 };
     const ctrl = createSessionController({ ...deps, session, firstItem: baseItem });
 
     ctrl._forceState(gradedState);
+    // _forceState bypasses #dispatch, so seed the scheduler history manually
+    // to simulate what the real listening→graded transition writes.
+    ctrl._seedRoundHistory([{ itemId: baseItem.id, degree: baseItem.degree, key: baseItem.key }]);
 
     await ctrl.next();
 
@@ -242,9 +245,9 @@ describe('SessionController — next()', () => {
     );
   });
 
-  it('completes the session when no due items remain despite target not reached', async () => {
+  it('completes the session when selectNextItem returns null despite target not reached', async () => {
     const deps = makeDeps();
-    deps.itemsRepo.findDue = vi.fn(async () => []); // empty queue
+    deps.itemsRepo.listAll = vi.fn(async () => []); // empty queue → selector returns null
     const session: Session = { ...baseSession, completed_items: 5, target_items: 30 };
     const ctrl = createSessionController({ ...deps, session, firstItem: baseItem });
 
@@ -395,7 +398,9 @@ describe('SessionController — attempt persistence on graded transition', () =>
 
   it('running #pitchPasses / #labelPasses are reflected in session completion', async () => {
     const deps = makeDeps();
-    deps.itemsRepo.findDue = vi.fn(async () => []);
+    // Empty queue path: selectNextItem returns null and next() falls through
+    // to session completion so we can observe the running counters.
+    deps.itemsRepo.listAll = vi.fn(async () => []);
     const session: Session = {
       ...baseSession,
       completed_items: 5,

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -211,6 +211,45 @@ describe('SessionController — next()', () => {
     expect(ctrl.targetAudio).toBeNull();
   });
 
+  it('selectNextItem() uses round history, not just currentItem id — blocks repeated degree even when currentItem differs', async () => {
+    // Regression pin: the previous implementation of next() used a naive
+    // `dueNow.find(i => i.id !== justPlayed)` bypass keyed off `currentItem.id`.
+    // The scheduler path (selectNextItem + roundHistory) and the naive path must
+    // disagree here, so a silent revert to the bypass would flip the assertion.
+    //
+    // Fixture:
+    //   - currentItem = nextItem (degree 1, id '1-C-major')
+    //   - roundHistory = [baseItem entry] (degree 5)
+    //   - listAll / findDue both return [baseItem, nextItem]
+    //
+    // Old naive code:
+    //   justPlayed = nextItem.id → find() skips nextItem → returns baseItem (degree 5)
+    //
+    // New scheduler:
+    //   roundHistory last entry degree=5 → isBlockedSameDegree(baseItem) → true →
+    //   only nextItem is eligible → returns nextItem (degree 1)
+    const nextItem: Item = { ...baseItem, id: '1-C-major', degree: 1 };
+    const deps = makeDeps();
+    // Stub both paths so whichever runs has a well-defined fixture. Order is
+    // chosen so the naive path would return baseItem (the wrong answer).
+    deps.itemsRepo.listAll = vi.fn(async () => [baseItem, nextItem]);
+    deps.itemsRepo.findDue = vi.fn(async () => [baseItem, nextItem]);
+    const session: Session = { ...baseSession, completed_items: 1, target_items: 30 };
+    // firstItem = nextItem so controller.currentItem starts as nextItem;
+    // this primes `justPlayed = nextItem.id` for the naive-path comparison.
+    const ctrl = createSessionController({ ...deps, session, firstItem: nextItem });
+
+    ctrl._forceState(gradedState);
+    ctrl._seedRoundHistory([{ itemId: baseItem.id, degree: baseItem.degree, key: baseItem.key }]);
+
+    await ctrl.next();
+
+    // Scheduler blocks degree 5 (in history) so the chosen item must have
+    // degree 1. The naive bypass would have returned baseItem (degree 5).
+    expect(ctrl.currentItem?.degree).toBe(1);
+    expect(ctrl.currentItem?.id).toBe(nextItem.id);
+  });
+
   it('completes the session when target_items is reached', async () => {
     const deps = makeDeps();
     // completed_items = 29, target_items = 30 → next() should complete

--- a/packages/web-platform/tests/session/select-next-item.integration.test.ts
+++ b/packages/web-platform/tests/session/select-next-item.integration.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { selectNextItem } from '@ear-training/core/scheduler/selection';
+import type { RoundHistoryEntry } from '@ear-training/core/scheduler/interleaving';
+import { buildInitialItems } from '@ear-training/core/seed/initial-items';
+import { createItemsRepo } from '@/store/items-repo';
+import { openTestDB } from '../helpers/test-db';
+
+/**
+ * Integration test for Plan C2 Task 5 (#113): verifies that wiring
+ * `selectNextItem()` against a real IndexedDB-backed items repo delivers the
+ * non-negotiable "no same-degree back-to-back" guarantee from the spec
+ * (§5.2 — interleaving + Leitner SRS, no blocked practice).
+ *
+ * The session controller at
+ *   apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+ * now calls this exact pair on every `next()`:
+ *   const items = await itemsRepo.listAll();
+ *   selectNextItem(items, roundHistory, now, rng);
+ * so verifying the pair end-to-end pins the anti-repeat contract the controller
+ * relies on. Controller-level anti-repeat coverage (via `_seedRoundHistory`) lives
+ * in apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts.
+ */
+describe('selectNextItem + items-repo integration — anti-repeat guarantee', () => {
+  it('never returns the same item on two consecutive picks when alternatives exist', async () => {
+    const db = await openTestDB();
+    const repo = createItemsRepo(db);
+    // Starter curriculum: 3 items (degrees 1, 3, 5 in C major) — enough
+    // alternatives so same-degree back-to-back is always avoidable.
+    await repo.putMany(buildInitialItems({ now: 0 }));
+
+    const history: RoundHistoryEntry[] = [];
+    // Deterministic rng so the test isn't flaky.
+    const rng = () => 0.5;
+
+    const first = selectNextItem(await repo.listAll(), history, 1_000, rng);
+    expect(first).not.toBeNull();
+    history.push({ itemId: first!.id, degree: first!.degree, key: first!.key });
+
+    const second = selectNextItem(await repo.listAll(), history, 2_000, rng);
+    expect(second).not.toBeNull();
+    // Anti-repeat: same-degree-back-to-back is explicitly blocked by the
+    // interleaving rule, so second must land on a different degree.
+    expect(second!.degree).not.toBe(first!.degree);
+    expect(second!.id).not.toBe(first!.id);
+  });
+
+  it('avoids same-degree repeat across 20 consecutive picks from the starter curriculum', async () => {
+    const db = await openTestDB();
+    const repo = createItemsRepo(db);
+    await repo.putMany(buildInitialItems({ now: 0 }));
+
+    const history: RoundHistoryEntry[] = [];
+    // Use Math.random so we cover non-deterministic rng paths too.
+    let now = 1_000;
+
+    for (let round = 0; round < 20; round++) {
+      const items = await repo.listAll();
+      const pick = selectNextItem(items, history, now, Math.random);
+      expect(pick).not.toBeNull();
+      if (history.length > 0) {
+        const prev = history[history.length - 1]!;
+        expect(pick!.degree).not.toBe(prev.degree);
+      }
+      history.push({ itemId: pick!.id, degree: pick!.degree, key: pick!.key });
+      now += 15_000; // 15s per round
+    }
+  });
+
+  it('returns null when the only eligible item is blocked and no alternatives exist', async () => {
+    const db = await openTestDB();
+    const repo = createItemsRepo(db);
+    // Seed only one item, then claim we just played its degree. Under the
+    // scheduler's soft-fallback (drops the same-key rule but keeps the
+    // same-degree rule), this single-item pool has no valid pick.
+    const [only] = buildInitialItems({ now: 0 });
+    await repo.put(only!);
+    const history: RoundHistoryEntry[] = [
+      { itemId: only!.id, degree: only!.degree, key: only!.key },
+    ];
+
+    const pick = selectNextItem(await repo.listAll(), history, 1_000, () => 0.5);
+    expect(pick).toBeNull();
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
  subgraph Before["Before — naive bypass (spec violation)"]
    B1[controller.next] --> B2["itemsRepo.findDue(now)"]
    B2 --> B3["dueNow.find(id != justPlayed) ?? dueNow[0]"]
    B3 -->|anti-repeat filter only| B4[currentItem]
  end

  subgraph After["After — Leitner + interleaving scheduler"]
    A1[controller.next] --> A2["itemsRepo.listAll()"]
    A2 --> A3["selectNextItem(items, roundHistory, now, rng)"]
    A3 -->|spec 5.2: no same-degree back-to-back,<br>no >3 same-key streak,<br>weighted by weakness + due + box bonus| A4[currentItem]
    A5[listening to graded<br>transition] -->|push entry on<br>successful persist| A6[#roundHistory]
    A6 -.feeds.-> A3
  end

  style Before stroke:#ef4444
  style After stroke:#22c55e
```

## Summary

- Replace the naive `dueNow.find(...) ?? dueNow[0]` bypass in `session-controller.svelte.ts` with `selectNextItem()` from `@ear-training/core/scheduler/selection` — the Leitner + interleaving scheduler that had zero production imports before this change despite 9 passing unit tests.
- Track `RoundHistoryEntry[]` across rounds. Each successful graded transition pushes `{ itemId, degree, key }`, enforcing spec 5.2 constraints ("no same-degree back-to-back", "no >3 consecutive same-key").
- Switch from `itemsRepo.findDue()` to `itemsRepo.listAll()` so the scheduler's mastered-warmup pool (30% share per spec) is visible. The scheduler handles due-weighting internally via each item's `due_at`.

Closes #113 — spec non-negotiable "interleaving + Leitner SRS, no blocked practice" is now production behavior, not dead code.

## Test plan

- [x] `pnpm run typecheck` — all packages green
- [x] `pnpm run test` — 349 passing (346 baseline + 3 new scheduler-with-real-IDB integration tests)
- [x] `pnpm run build` — clean production bundle
- [x] `pnpm run lint` — clean
- [x] Scheduler unit tests in `packages/core/tests/scheduler/selection.test.ts` pass unchanged
- [x] Updated controller unit test pins the same-degree anti-repeat contract (baseItem degree 5 in history → next pick must be degree != 5)
- [x] New `packages/web-platform/tests/session/select-next-item.integration.test.ts` verifies anti-repeat across 20 consecutive picks against real `fake-indexeddb` repos

## Notes for reviewer

- `_seedRoundHistory` is a new `@internal` test hook, guarded by `import.meta.env.MODE === 'production'` just like the existing `_forceState` / `_forceTimer` / `_forceRunningCounters` hooks. Not reachable from production bundles.
- The `+page.svelte` first-item fetch (line 38) still uses `findDue()` for the initial "anything due?" check. That's out of scope here — it only picks the seed item for `firstItem`; subsequent picks all go through `next()` and thus through the scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)