### PR TITLE
fix(ui): capture real wall-clock anchor for PitchTrace (C2/T7, #120)

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ActiveRound.svelte
@@ -25,9 +25,35 @@
   const cadenceStartAcTime = 0;
   const getCurrentTime = () => 0;
 
-  // windowStartMs and getNowMs are stubs — Task 6 wires real wall-clock offsets.
-  const windowStartMs = 0;
-  const getNowMs = () => 0;
+  // windowStartMs is the wall-clock timestamp (Date.now()-domain) of when the
+  // capture window started — i.e. when the controller dispatched PLAYBACK_DONE
+  // and transitioned into `listening`. We capture this on the reactive state
+  // transition rather than passing a stub (0 = Unix epoch) because pitch frames
+  // carry `at_ms = Date.now()`, so windowStartMs MUST be in the same domain or
+  // PitchTrace's (at_ms - windowStartMs) math produces billions and every frame
+  // clamps to the right edge (1.75T / 5000 * 480 ≈ billions). See GitHub #120 /
+  // Plan C2 Task 7.
+  //
+  // We keep the captured value stable across the listening → graded transition
+  // so the trace keeps showing the just-captured frames against the same time
+  // origin during the feedback panel. A new `listening` window recaptures.
+  let windowStartMs = $state(0);
+  const getNowMs = () => Date.now();
+
+  // Non-reactive transition tracker. Reading `controller.state.kind` inside
+  // $effect registers the dependency; `prevKind` is a plain module-local so
+  // writing it doesn't re-trigger the effect. We want to capture the anchor
+  // ONLY on the transition INTO `listening` — not on every PITCH_FRAME that
+  // arrives while already listening, which would continually reset the x-axis
+  // origin to "now" and leave the trace perpetually empty.
+  let prevKind: string | null = null;
+  $effect(() => {
+    const kind = controller.state.kind;
+    if (kind === 'listening' && prevKind !== 'listening') {
+      windowStartMs = Date.now();
+    }
+    prevKind = kind;
+  });
 
   const targetVisible = $derived(
     controller.state.kind === 'playing_target' || controller.state.kind === 'listening',


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    [*] --> idle
    idle --> playing_cadence: ROUND_STARTED
    playing_cadence --> playing_target: TARGET_STARTED
    playing_target --> listening: PLAYBACK_DONE
    note right of listening
        windowStartMs = Date.now()
        captured here (once)
    end note
    listening --> graded: CAPTURE_COMPLETE
    note right of graded
        windowStartMs preserved
        so feedback panel keeps
        the same x-axis origin
    end note
    graded --> idle: next()
```

## Summary

- Fix structural bug in pitch trace visualization (GitHub #120). ActiveRound passed \`windowStartMs: 0\` and \`getNowMs: () => 0\` as stubs to PitchTrace; with frame \`at_ms = Date.now()\`, the x-axis math produced ~billions and every frame clamped to the right edge.
- Capture \`Date.now()\` reactively on the transition INTO \`listening\` (post-PLAYBACK_DONE) and keep it stable across \`listening → graded\` so the feedback panel renders the same-origin trace.
- Use a non-reactive \`prevKind\` tracker inside \`\$effect\` so the anchor is captured ONCE per listening window — not reset on every PITCH_FRAME that accumulates while listening is active.

## Why the \`prevKind\` guard matters

Naive: \`\$effect(() => { if (kind === 'listening') windowStartMs = Date.now(); })\`.

The reducer mutates \`controller.state\` on every PITCH_FRAME (appending to \`state.frames\`). Svelte's reactive tracking sees \`controller.state.kind\` as an access on a potentially-changed object and re-fires the effect. Without \`prevKind\`, \`windowStartMs\` would reset to "now" every few ms, so all frames would have \`at_ms < windowStartMs\` and clamp to \`x = 0\` — trace looks perpetually empty instead of stuck right.

## Test plan

- [x] \`pnpm run typecheck\` — clean
- [x] \`pnpm run test\` — 354/354 pass (PitchTrace unit tests keep using prop-injected stubs, contract preserved)
- [x] \`pnpm run build\` — clean
- [x] \`pnpm run lint\` — clean

### Manual verification checklist for reviewer
- [ ] \`pnpm run dev\`, navigate to /scale-degree, start a round: confirm the pitch trace now-indicator sweeps left → right during the 5s capture window (not pinned to right edge)
- [ ] Confirm captured frames land along the timeline proportional to when they arrived, not stacked at x=480
- [ ] After \`graded\` transition, confirm the trace stays visible in the feedback state with frames at their original positions (didn't get re-anchored to a new "now")

Closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)