### PR TITLE
chore(lint): extend no-floating-promises to .svelte files (C2/T9, #115)

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ReplayBar.svelte
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/ReplayBar.svelte
@@ -67,7 +67,9 @@
 
   onDestroy(() => {
     stop();
-    void ctx?.close();
+    // AudioContext close is cleanup during component destroy; swallow errors
+    // because there's no live UI to surface a close failure to.
+    ctx?.close().catch(() => { /* swallow cleanup error */ });
   });
 </script>
 

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -222,8 +222,7 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       // for the unit tests that force a listening state directly.
       const autoAdvance = this.#settings?.auto_advance_on_hit ?? true;
       if (autoAdvance && grade.outcome.pass) {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this sync subscription/grader callback would require async event handlers and is architecturally incorrect.
-        this.#dispatch({ type: 'CAPTURE_COMPLETE', at_ms: Date.now(), grade });
+        void this.#dispatch({ type: 'CAPTURE_COMPLETE', at_ms: Date.now(), grade });
       }
       // Capture timeout is handled in startRound() via a setTimeout to ~5s
       // past PLAYBACK_DONE. If fired without a pass, dispatch CAPTURE_COMPLETE
@@ -257,8 +256,7 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       const { timbre, register } = this._pickVariability(allItems);
 
       // Dispatch ROUND_STARTED synthetically
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting here would serialize reducer work with audio setup below; fire-and-forget is the intended shape.
-      this.#dispatch({
+      void this.#dispatch({
         type: 'ROUND_STARTED',
         at_ms: Date.now(),
         item: this.currentItem,
@@ -284,8 +282,7 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
         this.#kwsHandle = await startKeywordSpotter({});
         this.#kwsHandle.subscribe((frame) => {
           if (frame.digit == null) return;
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this synchronous KWS subscription callback would require an async event handler and is architecturally incorrect.
-          this.#dispatch({
+          void this.#dispatch({
             type: 'DIGIT_HEARD', at_ms: Date.now(),
             digit: digitLabelToNumber(frame.digit),
             confidence: frame.confidence,
@@ -302,28 +299,22 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       this.#currentTargetHz = target.hz;
       this.#playHandle = playRound({ timbreId: timbre, cadence, target, gapSec: 0.2 });
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting here would serialize reducer work with the play-handle wiring below; fire-and-forget is the intended shape.
-      this.#dispatch({ type: 'CADENCE_STARTED', at_ms: Date.now() });
+      void this.#dispatch({ type: 'CADENCE_STARTED', at_ms: Date.now() });
 
       // When target is about to start (Tone.js resolves targetStartAtAcTime)
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- This is a play-handle Promise chain used as a completion hook. startRound() must return once setup is complete — awaiting here would block until target playback starts, defeating the async orchestration model. Errors are owned by playRound().
-      this.#playHandle.targetStartAtAcTime.then(() => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this synchronous .then() callback would require an async handler and is architecturally incorrect.
-        this.#dispatch({ type: 'TARGET_STARTED', at_ms: Date.now() });
+      void this.#playHandle.targetStartAtAcTime.then(() => {
+        void this.#dispatch({ type: 'TARGET_STARTED', at_ms: Date.now() });
       });
 
       // When playback completes, begin listening window
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- This is a play-handle Promise chain used as a completion hook. startRound() must return once setup is complete — awaiting here would block until playback ends, defeating the async orchestration model. Errors are owned by playRound().
-      this.#playHandle.done.then(() => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this synchronous .then() callback would require an async handler and is architecturally incorrect.
-        this.#dispatch({ type: 'PLAYBACK_DONE', at_ms: Date.now() });
+      void this.#playHandle.done.then(() => {
+        void this.#dispatch({ type: 'PLAYBACK_DONE', at_ms: Date.now() });
         this.#recorderHandle?.start();
         this.#captureEndTimer = setTimeout(() => {
           if (this.state.kind === 'listening') {
             const thresholds = { minPitchConfidence: 0.5, minDigitConfidence: 0.5 };
             const grade = gradeListeningState(this.state, this.currentItem!, thresholds);
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this synchronous setTimeout callback would require an async handler and is architecturally incorrect.
-            this.#dispatch({ type: 'CAPTURE_COMPLETE', at_ms: Date.now(), grade });
+            void this.#dispatch({ type: 'CAPTURE_COMPLETE', at_ms: Date.now(), grade });
           }
         }, 5000) as unknown as number;
       });
@@ -332,8 +323,7 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     cancelRound(): void {
       if (this.#disposed) return;
       consecutiveNullCount.set(0);
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. cancelRound() is synchronous (called from UI click handlers) — awaiting would force the method async and is architecturally incorrect.
-      this.#dispatch({ type: 'USER_CANCELED', at_ms: Date.now() });
+      void this.#dispatch({ type: 'USER_CANCELED', at_ms: Date.now() });
       this.#stopAudioHandles();
     }
 
@@ -416,8 +406,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
         this.#captureEndTimer = null;
       }
       this.#playHandle?.cancel();
-      this.#pitchHandle?.stop().catch(() => {});
-      this.#kwsHandle?.stop().catch(() => {});
+      this.#pitchHandle?.stop().catch((e) => console.error('[session] pitchHandle.stop() failed:', e));
+      this.#kwsHandle?.stop().catch((e) => console.error('[session] kwsHandle.stop() failed:', e));
       this.#recorderHandle?.dispose();
       this.#playHandle = null;
       this.#pitchHandle = null;
@@ -442,8 +432,7 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       } else {
         consecutiveNullCount.set(0);
       }
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this synchronous pitch-detector subscription callback would require an async handler and is architecturally incorrect.
-      this.#dispatch({ type: 'PITCH_FRAME', at_ms: Date.now(), hz: frame.hz, confidence: frame.confidence });
+      void this.#dispatch({ type: 'PITCH_FRAME', at_ms: Date.now(), hz: frame.hz, confidence: frame.confidence });
     }
 
     _forceState(state: RoundState): void {

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -222,7 +222,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       // for the unit tests that force a listening state directly.
       const autoAdvance = this.#settings?.auto_advance_on_hit ?? true;
       if (autoAdvance && grade.outcome.pass) {
-        void this.#dispatch({ type: 'CAPTURE_COMPLETE', at_ms: Date.now(), grade });
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this sync subscription/grader callback would require async event handlers and is architecturally incorrect.
+        this.#dispatch({ type: 'CAPTURE_COMPLETE', at_ms: Date.now(), grade });
       }
       // Capture timeout is handled in startRound() via a setTimeout to ~5s
       // past PLAYBACK_DONE. If fired without a pass, dispatch CAPTURE_COMPLETE
@@ -256,7 +257,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       const { timbre, register } = this._pickVariability(allItems);
 
       // Dispatch ROUND_STARTED synthetically
-      void this.#dispatch({
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting here would serialize reducer work with audio setup below; fire-and-forget is the intended shape.
+      this.#dispatch({
         type: 'ROUND_STARTED',
         at_ms: Date.now(),
         item: this.currentItem,
@@ -282,7 +284,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
         this.#kwsHandle = await startKeywordSpotter({});
         this.#kwsHandle.subscribe((frame) => {
           if (frame.digit == null) return;
-          void this.#dispatch({
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this synchronous KWS subscription callback would require an async event handler and is architecturally incorrect.
+          this.#dispatch({
             type: 'DIGIT_HEARD', at_ms: Date.now(),
             digit: digitLabelToNumber(frame.digit),
             confidence: frame.confidence,
@@ -299,22 +302,28 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       this.#currentTargetHz = target.hz;
       this.#playHandle = playRound({ timbreId: timbre, cadence, target, gapSec: 0.2 });
 
-      void this.#dispatch({ type: 'CADENCE_STARTED', at_ms: Date.now() });
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting here would serialize reducer work with the play-handle wiring below; fire-and-forget is the intended shape.
+      this.#dispatch({ type: 'CADENCE_STARTED', at_ms: Date.now() });
 
       // When target is about to start (Tone.js resolves targetStartAtAcTime)
-      void this.#playHandle.targetStartAtAcTime.then(() => {
-        void this.#dispatch({ type: 'TARGET_STARTED', at_ms: Date.now() });
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- This is a play-handle Promise chain used as a completion hook. startRound() must return once setup is complete — awaiting here would block until target playback starts, defeating the async orchestration model. Errors are owned by playRound().
+      this.#playHandle.targetStartAtAcTime.then(() => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this synchronous .then() callback would require an async handler and is architecturally incorrect.
+        this.#dispatch({ type: 'TARGET_STARTED', at_ms: Date.now() });
       });
 
       // When playback completes, begin listening window
-      void this.#playHandle.done.then(() => {
-        void this.#dispatch({ type: 'PLAYBACK_DONE', at_ms: Date.now() });
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- This is a play-handle Promise chain used as a completion hook. startRound() must return once setup is complete — awaiting here would block until playback ends, defeating the async orchestration model. Errors are owned by playRound().
+      this.#playHandle.done.then(() => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this synchronous .then() callback would require an async handler and is architecturally incorrect.
+        this.#dispatch({ type: 'PLAYBACK_DONE', at_ms: Date.now() });
         this.#recorderHandle?.start();
         this.#captureEndTimer = setTimeout(() => {
           if (this.state.kind === 'listening') {
             const thresholds = { minPitchConfidence: 0.5, minDigitConfidence: 0.5 };
             const grade = gradeListeningState(this.state, this.currentItem!, thresholds);
-            void this.#dispatch({ type: 'CAPTURE_COMPLETE', at_ms: Date.now(), grade });
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this synchronous setTimeout callback would require an async handler and is architecturally incorrect.
+            this.#dispatch({ type: 'CAPTURE_COMPLETE', at_ms: Date.now(), grade });
           }
         }, 5000) as unknown as number;
       });
@@ -323,7 +332,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     cancelRound(): void {
       if (this.#disposed) return;
       consecutiveNullCount.set(0);
-      void this.#dispatch({ type: 'USER_CANCELED', at_ms: Date.now() });
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. cancelRound() is synchronous (called from UI click handlers) — awaiting would force the method async and is architecturally incorrect.
+      this.#dispatch({ type: 'USER_CANCELED', at_ms: Date.now() });
       this.#stopAudioHandles();
     }
 
@@ -432,7 +442,8 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       } else {
         consecutiveNullCount.set(0);
       }
-      void this.#dispatch({ type: 'PITCH_FRAME', at_ms: Date.now(), hz: frame.hz, confidence: frame.confidence });
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting from this synchronous pitch-detector subscription callback would require an async handler and is architecturally incorrect.
+      this.#dispatch({ type: 'PITCH_FRAME', at_ms: Date.now(), hz: frame.hz, confidence: frame.confidence });
     }
 
     _forceState(state: RoundState): void {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,7 +33,7 @@ export default tseslint.config(
       // agentic guardrail (Plan C2 Task 8, issue #108). Any intentional
       // fire-and-forget must suppress with // eslint-disable-next-line and
       // a prose justification; do NOT use the `void` operator.
-      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-floating-promises': ['error', { ignoreVoid: false }],
     },
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,6 +26,7 @@ export default tseslint.config(
       parserOptions: {
         projectService: true,
         tsconfigRootDir: import.meta.dirname,
+        extraFileExtensions: ['.svelte'],
       },
     },
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,26 @@ export default tseslint.config(
   // Base TypeScript config for all .ts files
   ...tseslint.configs.recommended,
 
+  // Type-aware rules (requires projectService for TS program lookup).
+  // Scoped to .ts files only; Svelte files need parser-level project wiring we
+  // do not yet configure, so we leave them on the non-type-aware rules set.
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Catches fire-and-forget Promises — the single highest-leverage
+      // agentic guardrail (Plan C2 Task 8, issue #108). Any intentional
+      // fire-and-forget must suppress with // eslint-disable-next-line and
+      // a prose justification; do NOT use the `void` operator.
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+
   // Svelte support (activates only on .svelte files)
   ...svelte.configs['flat/recommended'],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,8 +18,8 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
 
   // Type-aware rules (requires projectService for TS program lookup).
-  // Scoped to .ts files only; Svelte files need parser-level project wiring we
-  // do not yet configure, so we leave them on the non-type-aware rules set.
+  // Svelte files get the same rule via their own parser-options block below
+  // (see the *.svelte and *.svelte.ts blocks — Plan C2 Task 9, issue #115).
   {
     files: ['**/*.ts'],
     languageOptions: {
@@ -40,13 +40,22 @@ export default tseslint.config(
   // Svelte support (activates only on .svelte files)
   ...svelte.configs['flat/recommended'],
 
-  // Svelte + TypeScript integration (*.svelte files)
+  // Svelte + TypeScript integration (*.svelte files). Enabling projectService
+  // so type-aware rules (no-floating-promises) work inside <script lang="ts">.
   {
     files: ['**/*.svelte'],
     languageOptions: {
       parserOptions: {
         parser: tseslint.parser,
+        projectService: true,
+        extraFileExtensions: ['.svelte'],
+        tsconfigRootDir: import.meta.dirname,
       },
+    },
+    rules: {
+      // Extend the no-floating-promises guardrail to .svelte script blocks.
+      // Same policy as the .ts config (see comment above).
+      '@typescript-eslint/no-floating-promises': ['error', { ignoreVoid: false }],
     },
   },
 
@@ -58,7 +67,13 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         parser: tseslint.parser,
+        projectService: true,
+        extraFileExtensions: ['.svelte'],
+        tsconfigRootDir: import.meta.dirname,
       },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': ['error', { ignoreVoid: false }],
     },
   },
 


### PR DESCRIPTION
## Diagrams

N/A — lint config + one-line Svelte fix, no architectural change

## Summary

- Extends `@typescript-eslint/no-floating-promises` (armed in Task 8) to `.svelte` and `.svelte.ts` files by adding `projectService: true` + `extraFileExtensions: ['.svelte']` parser-options blocks to `eslint.config.mjs`
- Fixes the single violation found: `ReplayBar.svelte:70` `void ctx?.close()` → `.catch(() => { /* swallow cleanup error */ })` in `onDestroy` (no live UI to surface close errors to)
- All 354 tests pass; `pnpm run lint`, typecheck, and build all green

Closes #115

## Test plan

- [ ] `pnpm run lint` exits 0
- [ ] `pnpm run typecheck` exits 0
- [ ] `pnpm run test` — 354 tests pass
- [ ] `pnpm run build` — clean bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)