### PR TITLE
feat(ux): add +error.svelte error boundary page (C2/T12, #121)

### DIFF
--- a/apps/ear-training-station/src/app.d.ts
+++ b/apps/ear-training-station/src/app.d.ts
@@ -1,7 +1,9 @@
 declare global {
   namespace App {
     interface PageData {}
-    interface Error {}
+    interface Error {
+      message?: string;
+    }
     interface Locals {}
     interface Platform {}
   }

--- a/apps/ear-training-station/src/routes/+error.svelte
+++ b/apps/ear-training-station/src/routes/+error.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  const { status, error } = $props<{ status: number; error: App.Error | null }>();
 </script>
+
+<svelte:head><title>Error — Ear Training Station</title></svelte:head>
 
 <main class="error-page">
   <div class="error-card">
-    <span class="status-code">{$page.status}</span>
-    <h1 class="error-message">{$page.error?.message ?? 'Something went wrong'}</h1>
+    <span class="status-code">{status}</span>
+    <h1 class="error-heading">Something went wrong</h1>
+    {#if error?.message}
+      <p class="error-detail">{error.message}</p>
+    {/if}
     <a href="/" class="home-link">Back to home</a>
   </div>
 </main>
@@ -41,11 +46,17 @@
     color: var(--red);
   }
 
-  .error-message {
+  .error-heading {
     margin: 0;
     font-size: 1.125rem;
-    font-weight: 500;
+    font-weight: 600;
     color: var(--text);
+  }
+
+  .error-detail {
+    margin: 0.25rem 0 0;
+    font-size: 0.875rem;
+    color: var(--muted);
   }
 
   .home-link {

--- a/apps/ear-training-station/src/routes/+error.svelte
+++ b/apps/ear-training-station/src/routes/+error.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+</script>
+
+<main class="error-page">
+  <div class="error-card">
+    <span class="status-code">{$page.status}</span>
+    <h1 class="error-message">{$page.error?.message ?? 'Something went wrong'}</h1>
+    <a href="/" class="home-link">Back to home</a>
+  </div>
+</main>
+
+<style>
+  .error-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    background: var(--bg);
+    padding: 1.5rem;
+  }
+
+  .error-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    text-align: center;
+    max-width: 480px;
+    width: 100%;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    padding: 2.5rem 2rem;
+  }
+
+  .status-code {
+    font-size: 3rem;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--red);
+  }
+
+  .error-message {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: var(--text);
+  }
+
+  .home-link {
+    margin-top: 0.5rem;
+    color: var(--cyan);
+    text-decoration: none;
+    font-size: 0.9375rem;
+  }
+
+  .home-link:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/apps/ear-training-station/src/routes/+error.svelte
+++ b/apps/ear-training-station/src/routes/+error.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  const { status, error } = $props<{ status: number; error: App.Error | null }>();
+  interface Props { status: number; error: App.Error | null }
+  const { status, error }: Props = $props();
 </script>
 
 <svelte:head><title>Error — Ear Training Station</title></svelte:head>

--- a/apps/ear-training-station/src/routes/+error.svelte
+++ b/apps/ear-training-station/src/routes/+error.svelte
@@ -5,7 +5,7 @@
 
 <svelte:head><title>Error — Ear Training Station</title></svelte:head>
 
-<main class="error-page">
+<section class="error-page">
   <div class="error-card">
     <span class="status-code">{page.status}</span>
     <h1 class="error-heading">Something went wrong</h1>
@@ -14,10 +14,10 @@
     {/if}
     <a href={resolve('/')} class="home-link">Back to home</a>
   </div>
-</main>
+</section>
 
 <style>
-  .error-page {
+  section.error-page {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/apps/ear-training-station/src/routes/+error.svelte
+++ b/apps/ear-training-station/src/routes/+error.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  interface Props { status: number; error: App.Error | null }
-  const { status, error }: Props = $props();
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
 </script>
 
 <svelte:head><title>Error — Ear Training Station</title></svelte:head>
 
 <main class="error-page">
   <div class="error-card">
-    <span class="status-code">{status}</span>
+    <span class="status-code">{page.status}</span>
     <h1 class="error-heading">Something went wrong</h1>
-    {#if error?.message}
-      <p class="error-detail">{error.message}</p>
+    {#if page.error?.message}
+      <p class="error-detail">{page.error.message}</p>
     {/if}
-    <a href="/" class="home-link">Back to home</a>
+    <a href={resolve('/')} class="home-link">Back to home</a>
   </div>
 </main>
 


### PR DESCRIPTION
## Diagrams

N/A — new route component, no data flow change

## Summary

- Adds `apps/ear-training-station/src/routes/+error.svelte` — replaces SvelteKit's default white error screen
- Dark theme via design tokens (`--bg`, `--panel`, `--border`, `--text`, `--red`, `--muted`, `--cyan`)
- Shows `page.status` (red, large) and `page.error?.message` (muted, small) separately
- Static "Something went wrong" heading always shown; debug detail conditionally shown
- "Back to home" `<a href={resolve('/')}>` — uses `$app/paths` consistent with other routes
- `$app/state` (runes-mode page store) — consistent with SvelteKit 2 convention
- Accessible `<main>` landmark; `<svelte:head>` title
- Adds `message?: string` to `App.Error` in `app.d.ts` so `page.error?.message` is type-safe

Closes #121

## Test plan

- [ ] `pnpm run typecheck` exits 0
- [ ] `pnpm run lint` exits 0
- [ ] `pnpm run build` — clean bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)