### PR TITLE
feat(replay): wire Target/Both buttons via Tone.Offline render (C2/T13, #109)

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -267,7 +267,7 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       });
 
       // Lazy-load the audio handles (web-platform modules)
-      const { playRound } = await import('@ear-training/web-platform/audio/player');
+      const { playRound, renderTargetBuffer } = await import('@ear-training/web-platform/audio/player');
       const { startPitchDetector } = await import('@ear-training/web-platform/pitch/pitch-detector');
       const { startKeywordSpotter } = await import('@ear-training/web-platform/speech/keyword-spotter');
       const { startAudioRecorder } = await import('@ear-training/web-platform/mic/recorder');
@@ -301,6 +301,26 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       const target = buildTarget(this.currentItem.key, this.currentItem.degree, register);
       this.#currentTargetHz = target.hz;
       this.#playHandle = playRound({ timbreId: timbre, cadence, target, gapSec: 0.2 });
+
+      // Render the target note to an AudioBuffer in parallel so the
+      // ReplayBar's Target / Both replay modes have a buffer to play.
+      // Offline rendering runs much faster than real time — a ~2s target
+      // renders in a few ms — so the buffer is ready well before the user
+      // reaches the graded state (earliest ~10s: cadence 3.2s + gap 0.2s +
+      // target 1.5s + 5s capture). Handled `.then(...).catch(...)` chain —
+      // replay is a non-essential affordance; a render failure must not
+      // block the round.
+      renderTargetBuffer({ timbreId: timbre, target })
+        .then((buf) => {
+          // Guard against a late-arriving render after the user advanced to
+          // the next round (which resets targetAudio to null in next()) or
+          // disposed the controller.
+          if (this.#disposed) return;
+          this.targetAudio = buf;
+        })
+        .catch((e) => {
+          console.warn('session-controller: target render failed', e);
+        });
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. Awaiting here would serialize reducer work with the play-handle wiring below; fire-and-forget is the intended shape.
       this.#dispatch({ type: 'CADENCE_STARTED', at_ms: Date.now() });

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -81,6 +81,7 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     #recorderHandle: RecorderHandle | null = null;
     #captureEndTimer: number | null = null;
     #disposed = false;
+    #renderToken: number = 0;
     #history: VariabilityHistory = { lastTimbre: null, lastRegister: null };
     // Round-history for the Leitner + interleaving scheduler. Populated on
     // each successful graded transition so selectNextItem() can enforce
@@ -235,6 +236,11 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       if (this.state.kind !== 'idle') return; // guard against double-start
       if (this.currentItem == null) return;
 
+      // Increment the render token so any in-flight renderTargetBuffer()
+      // from a prior canceled round will be discarded when it resolves.
+      this.#renderToken++;
+      this.targetAudio = null;
+
       // Load user settings lazily on the first round, then reuse for the life
       // of the session. settingsRepo.getOrDefault() falls back to
       // DEFAULT_SETTINGS if IDB read fails or the row is absent, so we never
@@ -311,16 +317,15 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       // replay is a non-essential affordance; a render failure must not
       // block the round.
       //
-      // Race guard: capture the item at render-start. If `next()` has
-      // advanced to a new round by the time the render resolves, the
-      // currentItem reference will differ and the buffer is discarded —
-      // otherwise a stale render would clobber the null reset in next()
-      // (and possibly a fresh render from the new round).
-      const renderedForItem = this.currentItem;
+      // Race guard: capture the render token at render-start. If the round
+      // is canceled (and optionally restarted) by the time the render
+      // resolves, the token will have been incremented and the stale buffer
+      // is discarded — preventing a timbre-A render from clobbering the
+      // null reset or a fresh timbre-B render from a new round on the same item.
+      const renderToken = this.#renderToken;
       renderTargetBuffer({ timbreId: timbre, target })
         .then((buf) => {
-          if (this.#disposed) return;
-          if (this.currentItem !== renderedForItem) return;
+          if (this.#disposed || renderToken !== this.#renderToken) return;
           this.targetAudio = buf;
         })
         .catch((e) => {
@@ -357,6 +362,11 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
     cancelRound(): void {
       if (this.#disposed) return;
       consecutiveNullCount.set(0);
+      // Invalidate any in-flight renderTargetBuffer() so a stale render from
+      // this round cannot clobber the buffer when the next round (possibly
+      // on the same item with a different timbre) kicks off.
+      this.#renderToken++;
+      this.targetAudio = null;
       // eslint-disable-next-line @typescript-eslint/no-floating-promises -- #dispatch is the internal event reducer; it transitions state and handles its own error paths. cancelRound() is synchronous (called from UI click handlers) — awaiting would force the method async and is architecturally incorrect.
       this.#dispatch({ type: 'USER_CANCELED', at_ms: Date.now() });
       this.#stopAudioHandles();

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -310,12 +310,17 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
       // target 1.5s + 5s capture). Handled `.then(...).catch(...)` chain —
       // replay is a non-essential affordance; a render failure must not
       // block the round.
+      //
+      // Race guard: capture the item at render-start. If `next()` has
+      // advanced to a new round by the time the render resolves, the
+      // currentItem reference will differ and the buffer is discarded —
+      // otherwise a stale render would clobber the null reset in next()
+      // (and possibly a fresh render from the new round).
+      const renderedForItem = this.currentItem;
       renderTargetBuffer({ timbreId: timbre, target })
         .then((buf) => {
-          // Guard against a late-arriving render after the user advanced to
-          // the next round (which resets targetAudio to null in next()) or
-          // disposed the controller.
           if (this.#disposed) return;
+          if (this.currentItem !== renderedForItem) return;
           this.targetAudio = buf;
         })
         .catch((e) => {

--- a/packages/web-platform/src/audio/player.ts
+++ b/packages/web-platform/src/audio/player.ts
@@ -102,3 +102,45 @@ export function playRound(input: PlayRoundInput): PlayRoundHandle {
     cancel,
   };
 }
+
+export interface RenderTargetInput {
+  timbreId: TimbreId;
+  target: NoteEvent;
+}
+
+/**
+ * Render the target note to an `AudioBuffer` using the same timbre as live
+ * playback. Used by the ReplayBar's Target / Both replay modes so the user
+ * can A/B their capture against the reference.
+ *
+ * Renders just the target note (no cadence) via `Tone.Offline`. A small tail
+ * is appended so long release envelopes (e.g. the `pad` timbre) don't click
+ * at the end of the buffer. Offline rendering typically runs much faster than
+ * real time — for a ~2s target the render is imperceptible.
+ *
+ * No unit tests: `Tone.Offline` requires a real AudioContext and is not
+ * meaningfully testable in Vitest/jsdom. Integration coverage is provided by
+ * the dev harness and the Playwright round-graded spec.
+ */
+export async function renderTargetBuffer(
+  input: RenderTargetInput,
+): Promise<AudioBuffer> {
+  // 0.5s tail for release envelopes (pad timbre has release=1.5s but the
+  // audible tail beyond 0.5s is near-silent; longer tails just inflate the
+  // buffer without perceptible benefit).
+  const durationSec = input.target.durationSec + 0.5;
+  const toneBuffer = await Tone.Offline((): void => {
+    const synth = getTimbre(input.timbreId).createSynth();
+    synth.toDestination();
+    synth.triggerAttackRelease(
+      midiToHz(input.target.midi),
+      input.target.durationSec,
+      0,
+    );
+  }, durationSec);
+  const buf = toneBuffer.get();
+  if (buf == null) {
+    throw new Error('renderTargetBuffer: Tone.Offline produced no buffer');
+  }
+  return buf;
+}


### PR DESCRIPTION
## Diagrams

N/A — no new routes or data-flow changes; existing ReplayBar buttons unblocked by populating targetAudio

## Summary

- Adds `renderTargetBuffer()` to `packages/web-platform/src/audio/player.ts` — uses `Tone.Offline()` to synthesize the target note into an AudioBuffer (single-digit ms, non-blocking)
- `session-controller.svelte.ts`: kicks off render in parallel after `playRound()`; assigns result to `this.targetAudio` with a per-round `#renderToken` guard
- Token-based guard handles cancel+restart on the same item — `cancelRound()` and `startRound()` both increment the token, invalidating any in-flight render from a prior round
- `ReplayBar.svelte` Target (`disabled={!targetBuffer}`) and Both (`disabled={!userBuffer || !targetBuffer}`) buttons unblock automatically via Svelte 5 reactivity once `targetAudio` is non-null
- 359 tests pass; lint, typecheck, build all green

Closes #109

## Test plan

- [ ] `pnpm run test` — 359 tests pass
- [ ] `pnpm run typecheck` exits 0
- [ ] `pnpm run lint` exits 0
- [ ] `pnpm run build` — clean bundle
- [ ] Manual: complete a round in dev server, verify Target/Both buttons in ReplayBar are enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)