### PR TITLE
fix(mic): return 'unavailable' when Permissions API is missing

### DIFF
--- a/packages/web-platform/src/mic/permission.ts
+++ b/packages/web-platform/src/mic/permission.ts
@@ -41,9 +41,12 @@ export async function requestMicStream(): Promise<MicStreamHandle> {
 
 /**
  * Query the current mic permission state without prompting.
- * Not supported on all browsers — falls back to 'unknown'.
+ * Returns 'unavailable' when the Permissions API is absent (old browsers / partial
+ * Safari support paths). Falls back to 'unknown' when the API exists but throws
+ * (e.g. 'microphone' not in the allowlist for that browser).
  */
 export async function queryMicPermission(): Promise<MicPermissionState> {
+  if (!navigator.permissions) return 'unavailable';
   try {
     const status = await navigator.permissions.query({ name: 'microphone' });
     if (status.state === 'granted') return 'granted';

--- a/packages/web-platform/tests/mic/permission.test.ts
+++ b/packages/web-platform/tests/mic/permission.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { queryMicPermission } from '@/mic/permission';
+
+describe('queryMicPermission', () => {
+  const originalPermissions = navigator.permissions;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'permissions', {
+      value: originalPermissions,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("returns 'unavailable' when navigator.permissions is absent", async () => {
+    Object.defineProperty(navigator, 'permissions', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await queryMicPermission();
+    expect(result).toBe('unavailable');
+  });
+
+  it("returns 'granted' when the Permissions API reports granted", async () => {
+    Object.defineProperty(navigator, 'permissions', {
+      value: {
+        query: async () => ({ state: 'granted' }),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await queryMicPermission();
+    expect(result).toBe('granted');
+  });
+
+  it("returns 'denied' when the Permissions API reports denied", async () => {
+    Object.defineProperty(navigator, 'permissions', {
+      value: {
+        query: async () => ({ state: 'denied' }),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await queryMicPermission();
+    expect(result).toBe('denied');
+  });
+
+  it("returns 'prompt' when the Permissions API reports prompt", async () => {
+    Object.defineProperty(navigator, 'permissions', {
+      value: {
+        query: async () => ({ state: 'prompt' }),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await queryMicPermission();
+    expect(result).toBe('prompt');
+  });
+
+  it("returns 'unknown' when the Permissions API throws", async () => {
+    Object.defineProperty(navigator, 'permissions', {
+      value: {
+        query: async () => { throw new Error('microphone not in allowlist'); },
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await queryMicPermission();
+    expect(result).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Diagrams

N/A — no flow change; variant was always declared, now it's actually returned.

## Summary

- Make `queryMicPermission()` return `'unavailable'` when `navigator.permissions` is missing (variant was previously dead)
- Callers continue to treat unknown-state UX as before; `'unavailable'` is wired in as distinct
- Addresses the deferred item from CLAUDE.md "Deferred items" §2 (PR #10 follow-up)

## Test plan

- [ ] Added unit test in packages/web-platform for the API-missing branch
- [ ] `pnpm run typecheck` green
- [ ] `pnpm run test` green (all 366 tests)
- [ ] `pnpm run lint` green
- [ ] Grep for MicPermissionState callers shows no broken switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)