### PR TITLE
fix(sw): precache index.html so NavigationRoute works offline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,12 +36,51 @@ jobs:
 
       - name: Run e2e tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         working-directory: apps/ear-training-station
-        run: pnpm exec playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        # offline-pwa.spec.ts requires a production build (vite preview) and runs in
+        # the separate e2e-pwa job below. testIgnore in playwright.config.ts also
+        # excludes it, but --grep-invert adds a safety net for any config drift.
+        run: pnpm exec playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --grep-invert offline-pwa
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-report-shard-${{ matrix.shardIndex }}
+          path: apps/ear-training-station/test-results/
+          retention-days: 7
+
+  # Separate non-sharded job for offline/PWA tests — requires a production build.
+  # Runs against `vite preview` so the service worker is active.
+  # See apps/ear-training-station/playwright.preview.config.ts for the Playwright config.
+  e2e-pwa:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm --filter ear-training-station exec playwright install chromium --with-deps
+
+      - name: Build production app (required for service worker)
+        run: pnpm run build
+
+      - name: Run offline/PWA e2e tests
+        working-directory: apps/ear-training-station
+        run: pnpm exec playwright test --config playwright.preview.config.ts
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: playwright-report-pwa
           path: apps/ear-training-station/test-results/
           retention-days: 7

--- a/apps/ear-training-station/e2e/offline-pwa.spec.ts
+++ b/apps/ear-training-station/e2e/offline-pwa.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Offline / PWA boot tests.
+ *
+ * These tests run exclusively against the PRODUCTION build served by `vite preview`
+ * (port 4173, via playwright.preview.config.ts). The Vite dev server does NOT
+ * emit a service worker (devOptions.enabled: false in vite.config.ts), so offline
+ * tests cannot work against the dev server.
+ *
+ * CI: the e2e-pwa job runs `pnpm run build` as a dedicated step before launching
+ * `vite preview`, so the SW is present in build/.
+ *
+ * Local: run `pnpm run build` once, then:
+ *   pnpm exec playwright test --config playwright.preview.config.ts
+ *
+ * ── What we test ──────────────────────────────────────────────────────────────
+ * 1. SW registers, installs, and activates on first visit.
+ * 2. App shell renders correctly when offline after SW has precached assets.
+ * 3. SW-served JS/CSS assets are returned from cache (fromServiceWorker: true)
+ *    after the SW is active.
+ *
+ * ── Fix confirmed ─────────────────────────────────────────────────────────────
+ * The SvelteKitPWA config now uses `kit.adapterFallback: 'index.html'` and
+ * `kit.spa: true`, which adds `index.html` (keyed as `{url: 'index.html', ...}`)
+ * to the precache manifest with a revision derived from `_app/version.json`.
+ * The `NavigationRoute(createHandlerBoundToURL('index.html'))` therefore has a
+ * precache entry to resolve and can serve the HTML shell offline.
+ *
+ * ── Why not a full round offline? ─────────────────────────────────────────────
+ * The KWS TensorFlow model shards are fetched from tfhub.dev /
+ * storage.googleapis.com at runtime (CacheFirst, "tfjs-models-cache"). In a
+ * headless e2e environment those requests never fire because Playwright uses
+ * fake-device media streams that bypass the KWS pipeline. A full offline round
+ * would hit a network error on the KWS fetch rather than testing the SW shell.
+ */
+import { test, expect } from '@playwright/test';
+import { seedOnboarded } from './helpers/app-state';
+
+/**
+ * Wait for the service worker to activate and control the page.
+ *
+ * `navigator.serviceWorker.ready` resolves when SW is in `activated` state,
+ * but `page.evaluate` with a long-running Promise can race against Playwright's
+ * evaluate timeout. `waitForFunction` polls the condition with an explicit
+ * timeout instead, which is more resilient against slow SW installs.
+ */
+async function waitForSWController(page: import('@playwright/test').Page): Promise<void> {
+  // First, wait until the SW is active (ready resolves).
+  // We set a 30s timeout to allow the SW to finish precaching all assets.
+  await page.waitForFunction(
+    () =>
+      navigator.serviceWorker.ready.then(() => true).catch(() => false),
+    { timeout: 30_000 },
+  );
+  // Then confirm it's controlling the page.
+  await page.waitForFunction(
+    () => navigator.serviceWorker.controller !== null,
+    { timeout: 15_000 },
+  );
+}
+
+test.describe('offline PWA boot', () => {
+  test('service worker activates and controls the page', async ({ page }) => {
+    await seedOnboarded(page);
+    await page.goto('/');
+
+    await waitForSWController(page);
+
+    const isControlled = await page.evaluate(
+      () => navigator.serviceWorker.controller !== null,
+    );
+    expect(isControlled).toBe(true);
+  });
+
+  test('app shell renders when offline', async ({ page, context }) => {
+    // ── Phase 1: first visit (online) — warm the SW precache ──────────────────
+    await seedOnboarded(page);
+    await page.goto('/');
+
+    // Wait for install+activate to complete so the precache is fully warm.
+    await waitForSWController(page);
+
+    // Reload once online to confirm the SW is controlling the page before going
+    // offline. This also exercises the SW's asset-serving path.
+    await page.reload({ waitUntil: 'networkidle', timeout: 30_000 });
+
+    // ── Phase 2: go offline + reload — SW must serve the shell from cache ──────
+    await context.setOffline(true);
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 15_000 });
+
+    // The navigation <nav> rendered by +layout.svelte must be visible.
+    // This confirms the SW served index.html offline (NavigationRoute hit).
+    await expect(page.locator('nav').first()).toBeVisible({ timeout: 10_000 });
+
+    // ── Phase 3: restore network ───────────────────────────────────────────────
+    await context.setOffline(false);
+  });
+
+  test('critical assets served from SW cache when online', async ({ page }) => {
+    // After SW activation, JS and CSS immutable chunks must be served from the
+    // Workbox precache (fromServiceWorker: true). This confirms the precache is
+    // populated and the SW is intercepting asset requests — a prerequisite for
+    // the offline scenario to work.
+    await seedOnboarded(page);
+    await page.goto('/');
+
+    await waitForSWController(page);
+
+    // Collect immutable asset responses after the SW is active.
+    const assetResponses: Array<{ url: string; fromSW: boolean; status: number }> = [];
+    page.on('response', (response) => {
+      const url = response.url();
+      if (url.includes('/_app/immutable/')) {
+        assetResponses.push({
+          url,
+          fromSW: response.fromServiceWorker(),
+          status: response.status(),
+        });
+      }
+    });
+
+    // Reload to trigger asset fetches while the SW is active. On the second
+    // load, Workbox serves precached assets from cache rather than the network.
+    await page.reload({ waitUntil: 'networkidle', timeout: 30_000 });
+
+    // At least some immutable assets must be served by the SW.
+    const swAssets = assetResponses.filter((r) => r.fromSW);
+    expect(
+      swAssets.length,
+      `Expected at least one immutable asset to be served from SW cache. ` +
+        `Got ${assetResponses.length} asset responses total, ${swAssets.length} from SW.`,
+    ).toBeGreaterThan(0);
+
+    // All SW-served assets must have a 200 status.
+    const badStatus = swAssets.filter((r) => r.status !== 200);
+    expect(
+      badStatus,
+      `SW-served assets with non-200 status: ${badStatus.map((r) => `${r.status} ${r.url}`).join(', ')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/apps/ear-training-station/playwright.config.ts
+++ b/apps/ear-training-station/playwright.config.ts
@@ -23,6 +23,10 @@ const audioFile = fileURLToPath(new URL('./e2e/fixtures/a4-sine.wav', import.met
 export default defineConfig({
   testDir: './e2e',
   testMatch: '**/*.spec.ts',
+  // offline-pwa.spec.ts requires a production build served by `vite preview` —
+  // it cannot run against the Vite dev server (SW not emitted in dev mode).
+  // Run it via `pnpm exec playwright test --config playwright.preview.config.ts`.
+  testIgnore: /offline-pwa\.spec\.ts$/,
   timeout: 60_000,
   use: {
     baseURL: 'http://localhost:5273',

--- a/apps/ear-training-station/playwright.preview.config.ts
+++ b/apps/ear-training-station/playwright.preview.config.ts
@@ -1,0 +1,55 @@
+/**
+ * Playwright config for the offline/PWA e2e tests.
+ *
+ * Requires a production build before running — `pnpm run build` must complete
+ * successfully so that dist/ contains the compiled service worker.
+ *
+ * Serves the build via `vite preview` on port 4173.  The service worker is
+ * only emitted during `vite build` (devOptions.enabled: false in vite.config.ts),
+ * which is why these tests cannot run against the dev server used by the default
+ * playwright.config.ts.
+ *
+ * Usage:
+ *   pnpm run build
+ *   pnpm exec playwright test --config playwright.preview.config.ts
+ *
+ * CI: see .github/workflows/e2e.yml — the e2e-pwa job runs `pnpm run build` as a
+ * dedicated step, then uses this config for a non-sharded single-job run.
+ *
+ * Launch flags: same rationale as playwright.config.ts (autoplay, audio sandbox).
+ * The fake-capture flags are retained so the audio stack initialises without
+ * errors even though no audio round is attempted in the offline tests.
+ */
+import { defineConfig } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const audioFile = fileURLToPath(new URL('./e2e/fixtures/a4-sine.wav', import.meta.url));
+
+export default defineConfig({
+  testDir: './e2e',
+  // Only run the offline-pwa spec via this config.
+  testMatch: /offline-pwa\.spec\.ts$/,
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://localhost:4173',
+    launchOptions: {
+      args: [
+        '--use-fake-ui-for-media-stream',
+        '--use-fake-device-for-media-stream',
+        `--use-file-for-fake-audio-capture=${audioFile}`,
+        '--autoplay-policy=no-user-gesture-required',
+        ...(process.platform === 'darwin' ? ['--disable-features=AudioServiceSandbox'] : []),
+      ],
+      ignoreDefaultArgs: ['--mute-audio'],
+    },
+  },
+  webServer: {
+    // Serves the production build (build/) which includes the compiled service worker.
+    // Prerequisite: build/ must exist — run `pnpm run build` first.
+    // pnpm exec vite avoids the arg-passthrough `--` issue (see CLAUDE.md).
+    command: 'pnpm exec vite preview --port 4173 --strictPort',
+    url: 'http://localhost:4173/',
+    reuseExistingServer: true,
+    timeout: 30_000,
+  },
+});

--- a/apps/ear-training-station/vite.config.ts
+++ b/apps/ear-training-station/vite.config.ts
@@ -75,7 +75,15 @@ export default defineConfig({
       },
       workbox: {
         // Precache all SvelteKit-generated app shell assets.
+        // `html` is intentionally omitted here — the index.html SPA shell is
+        // added to the precache via `kit.adapterFallback` + `kit.spa` below,
+        // which uses the version.json hash as the revision so the cached shell
+        // is invalidated on every new SW deployment.
         globPatterns: ['client/**/*.{js,css,ico,png,svg,webmanifest}'],
+        // navigateFallback must be '/' — the URL the server actually serves the
+        // HTML shell at. Combined with spa.fallbackMapping: '/', Workbox precaches
+        // {url: '/'} and NavigationRoute serves '/' for all offline navigations.
+        navigateFallback: '/',
         runtimeCaching: [
           {
             // Cache TensorFlow Hub model shards loaded by speech-commands at runtime.
@@ -97,6 +105,20 @@ export default defineConfig({
       kit: {
         // adapter-static uses 'static' as the assets dir by default.
         assets: 'static',
+        // Tell SvelteKitPWA that adapter-static uses index.html as the SPA
+        // fallback. Combined with spa.fallbackMapping: '/', the plugin adds
+        // {url: '/', revision: <hash-of-version.json>} to the precache manifest
+        // so the NavigationRoute can serve the HTML shell offline.
+        // The revision is re-derived from version.json on every build, ensuring
+        // stale cached shells are replaced when a new SW is deployed.
+        adapterFallback: 'index.html',
+        spa: {
+          // fallbackMapping: '/' causes the precache entry to use '/' as the
+          // URL (not 'index.html'), which the preview / production server
+          // actually serves. Without this, Workbox would try to precache
+          // /index.html which returns 404 on the static server.
+          fallbackMapping: '/',
+        },
       },
       devOptions: {
         // Enable in dev only if you want to test SW registration locally.


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
  participant U as User
  participant P as Page
  participant SW as Service Worker
  participant N as Network
  U->>P: first visit (online)
  P->>N: fetch shell + assets
  N-->>SW: populates cache (now includes '/' → index.html)
  U->>P: go offline + reload
  P->>SW: navigate to '/'
  SW-->>P: serve cached '/' (NavigationRoute hit)
  P-->>U: shell renders without network
```

## Summary

- **Fix:** `vite.config.ts` SvelteKitPWA config now uses `kit.adapterFallback: 'index.html'` + `kit.spa: { fallbackMapping: '/' }` + `workbox.navigateFallback: '/'`. This adds `{url: '/', revision: <version-hash>}` to the precache manifest so `NavigationRoute(createHandlerBoundToURL('/'))` has a valid entry to serve offline. Before this fix, offline reload returned ERR_INTERNET_DISCONNECTED even though the SW was active and 42 JS/CSS chunks were cached. The root issue: `globPatterns` alone can't pick up `index.html` because adapter-static writes it to `build/` after the SvelteKit build runs, not to `.svelte-kit/output/client/`. The SvelteKitPWA `spa` mode properly handles this by hashing `version.json` as the revision source.
- **Test infrastructure:** new `playwright.preview.config.ts` targets a `vite preview` build on port 4173 (offline tests can't run against the dev server — SW is disabled in dev mode). Existing `playwright.config.ts` excludes the new spec via `testIgnore`.
- **CI:** new `e2e-pwa` job in `e2e.yml` builds then runs the preview spec. The sharded dev-server `e2e` job excludes `offline-pwa` via both `testIgnore` and `--grep-invert`.
- **Spec:** `e2e/offline-pwa.spec.ts` covers SW activation, offline-shell boot (nav is visible after going offline + reload), and SW-served asset verification.

Closes #118.

## Test plan

- [x] Offline spec passes locally via preview config (3 tests, all green)
- [x] Existing `pnpm run test:e2e` suite unchanged and green (23 passed, 1 skipped — no regression)
- [x] `pnpm run typecheck` + `pnpm run lint` green
- [x] Manual build inspection confirms `{url:"/",revision:"401ba07638b02f52c5b61fa6d010b5d5"}` in `build/sw.js` precache — index.html shell is now precached

🤖 Generated with [Claude Code](https://claude.com/claude-code)