### PR TITLE
fix(shell): catch sync IDB.open throw so Safari private doesn't blank

### DIFF
--- a/apps/ear-training-station/e2e/idb-failure.spec.ts
+++ b/apps/ear-training-station/e2e/idb-failure.spec.ts
@@ -41,17 +41,13 @@ import type { Item } from '@ear-training/core/types/domain';
 
 // ── Case A: IDB open() throws (Safari private mode) ──────────────────────────
 //
-// BUG: the +layout.ts load() calls getDeps() → openEarTrainingDB() →
-// indexedDB.open(). When open() throws synchronously, SvelteKit's client-side
-// router receives an unhandled rejection and leaves the page blank instead of
-// rendering the error boundary or DegradationBanner. The onMount
-// handleHydrationError path is never reached.
-//
-// This test is marked fixme to document the expected behavior; enable it when
-// the load() function is updated to catch IDB failures and set persistenceFailing
-// (or redirect to the error page) rather than letting the rejection propagate.
+// The +layout.ts load() wraps getDeps()/settings.getOrDefault() in a try/catch.
+// When indexedDB.open throws synchronously (Safari private mode / Firefox strict
+// privacy), the catch handler calls handleHydrationError() to flip
+// degradationState.persistenceFailing and returns DEFAULT_SETTINGS so the shell
+// still renders. DegradationBanner surfaces the "Saving locally failed" message.
 
-test.fixme(
+test(
   'Case A: indexedDB.open throws — DegradationBanner shows "Saving locally failed"',
   async ({ page }) => {
     // Stub BEFORE any page script runs. Safari private mode (and historical
@@ -73,7 +69,10 @@ test.fixme(
     ).toBeVisible({ timeout: 10_000 });
 
     // The shell header must still render (not a blank page / error boundary).
-    await expect(page.getByText(/ear training/i)).toBeVisible();
+    // Target the logo link specifically to avoid matching the onboarding
+    // headline "Ear training that uses your voice" (the redirect to
+    // /onboarding fires because DEFAULT_SETTINGS.onboarded is false).
+    await expect(page.getByRole('link', { name: 'Ear Training' })).toBeVisible();
   },
 );
 

--- a/apps/ear-training-station/src/routes/+layout.ts
+++ b/apps/ear-training-station/src/routes/+layout.ts
@@ -1,12 +1,32 @@
 import { redirect } from '@sveltejs/kit';
 import { getDeps } from '$lib/shell/deps';
+import { handleHydrationError } from '$lib/shell/stores';
+import { DEFAULT_SETTINGS, type Settings } from '@ear-training/core/types/domain';
 
 export const prerender = false;
 export const ssr = false;
 
 export async function load({ url }: { url: URL }) {
-  const { settings: repo } = await getDeps();
-  const settings = await repo.getOrDefault();
+  // In Safari private mode (and historical Firefox strict privacy) the very
+  // first `indexedDB.open` call inside `getDeps()` throws synchronously with a
+  // SecurityError. Without a try/catch here the rejection propagates past
+  // SvelteKit's client-side router and the page goes completely blank — no
+  // error boundary, no DegradationBanner, no `handleHydrationError` path.
+  //
+  // Catch IDB failures here, flip `degradationState.persistenceFailing` via
+  // the shared `handleHydrationError`, and return DEFAULT_SETTINGS so the
+  // shell still renders in memory-only mode. The same store flag that covers
+  // write failures mid-session (Case B in the idb-failure e2e) now also
+  // covers open failures at boot (Case A). See GitHub #119.
+  let settings: Settings;
+  try {
+    const { settings: repo } = await getDeps();
+    settings = await repo.getOrDefault();
+  } catch (err) {
+    handleHydrationError(err);
+    settings = { ...DEFAULT_SETTINGS };
+  }
+
   if (!settings.onboarded && !url.pathname.startsWith('/onboarding')) {
     throw redirect(302, '/onboarding');
   }


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
  [*] --> load
  load --> hydrated: IDB open OK
  load --> degraded: IDB open throws (NEW — caught)
  degraded --> render: persistenceFailing = true
  render --> [*]: DegradationBanner visible, routes work
  load --> blank: (OLD BEHAVIOR — fixed)
  blank --> [*]: page blank, user stuck
```

## Summary

- **Root cause:** `+layout.ts`'s `load()` called `openEarTrainingDB()` with no error handling. Sync throws (Safari private) propagated past the router and the page went blank.
- **Fix:** wrap the call, set `degradationState.persistenceFailing`, return a degraded shape. Shell renders in memory-only mode; DegradationBanner surfaces.
- **Test:** Case A in `idb-failure.spec.ts` un-fixme'd — now passes against the fix.
- Found via probe #119 (PR #148, merged earlier today).

## Test plan

- [x] `idb-failure.spec.ts` Case A passes (was `test.fixme`)
- [x] `idb-failure.spec.ts` Case B still passes (no regression on mid-session quota)
- [x] Full `pnpm run test:e2e` green
- [x] `pnpm run test` + `pnpm run typecheck` + `pnpm run lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)