### PR TITLE
fix(kws): register tfjs chained ops so argMax resolves on inference

### DIFF
--- a/packages/web-platform/package.json
+++ b/packages/web-platform/package.json
@@ -9,6 +9,7 @@
     "@tensorflow-models/speech-commands": "0.5.4",
     "@tensorflow/tfjs-backend-cpu": "3.21.0",
     "@tensorflow/tfjs-backend-webgl": "3.21.0",
+    "@tensorflow/tfjs-core": "3.21.0",
     "idb": "8.0.0",
     "tone": "15.1.22"
   },

--- a/packages/web-platform/src/speech/kws-loader.ts
+++ b/packages/web-platform/src/speech/kws-loader.ts
@@ -1,5 +1,14 @@
 import '@tensorflow/tfjs-backend-webgl';
 import '@tensorflow/tfjs-backend-cpu';
+// Attach chained ops (e.g. `tensor.argMax(...)`) to the Tensor prototype.
+// The tfjs-core package exposes ops as standalone functions by default; the
+// chained-method forms that speech-commands@0.5.4 calls (notably
+// `y.argMax(-1)` inside BROWSER_FFT recognition) are only registered when
+// this side-effect module is imported. The tfjs backends alone do NOT
+// register chained ops — they only register kernels. Without this import,
+// every inference frame throws `o.argMax is not a function` and no digit is
+// ever emitted. See GitHub #156.
+import '@tensorflow/tfjs-core/dist/public/chained_ops/register_all_chained_ops';
 import * as speechCommands from '@tensorflow-models/speech-commands';
 
 export type Recognizer = speechCommands.SpeechCommandRecognizer;

--- a/packages/web-platform/tests/speech/kws-tfjs-chained-ops.test.ts
+++ b/packages/web-platform/tests/speech/kws-tfjs-chained-ops.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Regression test for GitHub #156.
+ *
+ * speech-commands@0.5.4 calls `tensor.argMax(-1)` on every inference frame.
+ * That chained method is only registered on Tensor.prototype when the
+ * `register_all_chained_ops` side-effect module is imported. The tfjs
+ * backends (webgl / cpu) do NOT register chained ops — they only register
+ * kernels. Without the explicit chained-ops import in kws-loader.ts every
+ * KWS frame fails with `o.argMax is not a function` and no digit is ever
+ * emitted.
+ *
+ * Importing the loader here executes its module-level side-effect imports,
+ * which must attach `argMax` (and the rest of the chained ops) to the
+ * Tensor prototype. Without the fix this assertion fails.
+ */
+describe('kws-loader installs tfjs chained ops on import', () => {
+  it('Tensor.prototype.argMax is defined after importing kws-loader', async () => {
+    // Side-effect import: this executes the register_all_chained_ops hooks.
+    await import('../../src/speech/kws-loader');
+
+    const tfCore = await import('@tensorflow/tfjs-core');
+    // Tensor class is the recipient of the chained-op prototype assignments.
+    // No tensor instance is constructed to avoid triggering backend-selection
+    // side effects under jsdom (which logs noisy warnings but isn't needed
+    // for this prototype check).
+    const TensorClass = tfCore.Tensor as unknown as { prototype: { argMax?: unknown } };
+    expect(typeof TensorClass.prototype.argMax).toBe('function');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       '@tensorflow/tfjs-backend-webgl':
         specifier: 3.21.0
         version: 3.21.0(@tensorflow/tfjs-core@3.21.0)
+      '@tensorflow/tfjs-core':
+        specifier: 3.21.0
+        version: 3.21.0
       idb:
         specifier: 8.0.0
         version: 8.0.0


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
  participant App
  participant KWS as kws-loader
  participant TF as @tensorflow/tfjs-core
  participant SC as speech-commands

  Note over App,SC: BEFORE (#156 repro)
  App->>KWS: import kws-loader
  KWS->>TF: import webgl backend
  KWS->>TF: import cpu backend
  Note over TF: kernels registered<br/>chained ops NOT registered
  App->>SC: recognizer.listen(...)
  SC->>TF: y.argMax(-1)
  TF--xSC: TypeError: o.argMax is not a function
  Note over SC: every inference frame throws<br/>digitHeard = null

  Note over App,SC: AFTER
  App->>KWS: import kws-loader
  KWS->>TF: import webgl backend
  KWS->>TF: import cpu backend
  KWS->>TF: import register_all_chained_ops
  Note over TF: Tensor.prototype.argMax = ...<br/>(and ~200 other ops)
  App->>SC: recognizer.listen(...)
  SC->>TF: y.argMax(-1)
  TF-->>SC: Tensor<int32>
  Note over SC: digit emitted normally
```

## Summary
- speech-commands@0.5.4 calls `tensor.argMax(-1)` via its BROWSER_FFT pipeline every inference frame. That chained method is only attached to `Tensor.prototype` when `@tensorflow/tfjs-core/dist/public/chained_ops/register_all_chained_ops` is imported. The tfjs webgl/cpu backends we already import register **kernels**, not chained ops.
- Without that side-effect import, every KWS frame threw `o.argMax is not a function`. The error was swallowed inside speech-commands' internal RxJS pipeline, so `digitHeard` silently stayed `null` and users saw the "we're not hearing anything clearly" degradation banner regardless of mic state.
- Declare a direct dep on `@tensorflow/tfjs-core@3.21.0` (matches the existing webgl/cpu backend pins — tfjs v3 pinning is load-bearing per `CLAUDE.md`) so pnpm makes the package resolvable at our import path.
- Add a unit test asserting `Tensor.prototype.argMax` is installed after importing `kws-loader`, so this can't silently regress.

## Phase 1 results (reproduce)

| Build | argMax errors in ~10s | digitHeard works? |
|-------|-----------------------|-------------------|
| Vite dev (before fix) | 21 | no — null every frame |
| Prod bundle (before fix) | bundle contains no `prototype.argMax =` assignment (static analysis) — confirmed the same root cause |
| Vite dev (after fix) | 0 | "Digit recognizer started" in harness log |
| Prod bundle (after fix) | bundle now contains the chained-op registration |

The root cause is not Vite-mode-specific: the backend imports do not pull in chained-op registration in either dev or prod. The dev repro was louder only because `vite preview` can't load the YIN AudioWorklet (MIME), so `startRound()` aborts before KWS ever runs unless driven directly — which is how the static-analysis check confirmed the prod bug.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test` — 367 passing (was 366 + new regression test)
- [x] `pnpm --filter ear-training-station exec playwright test` — 25 passed, 1 skipped (unchanged)
- [x] Dev harness driven via Playwright confirms 0 argMax errors after fix (was ~21 in 10s)

Closes #156