### PR TITLE
feat(web-platform): add sessionsRepo.advance() for mid-session persistence

### DIFF
--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.integration.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.integration.test.ts
@@ -46,7 +46,7 @@ async function makeRealDeps(db: DB) {
     firstItem: baseItem,
     itemsRepo,
     attemptsRepo,
-    sessionsRepo: { start: vi.fn(), complete: vi.fn(), get: vi.fn(async () => baseSession), findRecent: vi.fn(async () => []) },
+    sessionsRepo: { start: vi.fn(), advance: vi.fn(), complete: vi.fn(), get: vi.fn(async () => baseSession), findRecent: vi.fn(async () => []) },
     settingsRepo: {
       getOrDefault: vi.fn(async () => ({ function_tooltip: true, auto_advance_on_hit: true, session_length: 30, reduced_motion: 'auto' as const, onboarded: true })),
       update: vi.fn(),

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.rca-155.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.rca-155.test.ts
@@ -88,6 +88,7 @@ describe('SessionController next() — RCA #155 repro', () => {
       attemptsRepo,
       sessionsRepo: {
         start: vi.fn(),
+        advance: vi.fn(),
         complete: sessionsComplete,
         get: vi.fn(async () => sessionRow),
         findRecent: vi.fn(async () => []),

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.svelte.ts
@@ -437,6 +437,23 @@ export function createSessionController(deps: SessionControllerDeps): SessionCon
         return;
       }
 
+      // Persist mid-session progress BEFORE mutating in-memory state.
+      // Issue #157: previously we only updated this.session here and relied on
+      // the final complete() to flush counters to IDB. A crash/reload between
+      // rounds left the persisted row showing completed_items: 0 despite N
+      // attempts existing. advance() writes the counters in place so the row
+      // always reflects progress-so-far.
+      //
+      // We await the write so a repo failure surfaces before we visually
+      // advance the UI; errors bubble out of next() and are handled by the
+      // caller (the session route boundary). The in-memory session update
+      // below is kept — it's load-bearing for the UI between rounds.
+      await deps.sessionsRepo.advance(sessionRow.id, {
+        completed_items: completed,
+        pitch_pass_count: this.#pitchPasses,
+        label_pass_count: this.#labelPasses,
+      });
+
       this.currentItem = next;
       this.session = { ...sessionRow, completed_items: completed };
       this.state = { kind: 'idle' };

--- a/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
+++ b/apps/ear-training-station/src/lib/exercises/scale-degree/internal/session-controller.test.ts
@@ -43,7 +43,7 @@ function makeDeps() {
     firstItem: baseItem,
     itemsRepo: { get: vi.fn(), listAll: vi.fn(async () => []), findDue: vi.fn(async () => [baseItem]), findByBox: vi.fn(), put: vi.fn(), putMany: vi.fn() },
     attemptsRepo: { append: vi.fn(), findBySession: vi.fn(async () => []), findByItem: vi.fn() },
-    sessionsRepo: { start: vi.fn(), complete: vi.fn(), get: vi.fn(async () => baseSession), findRecent: vi.fn() },
+    sessionsRepo: { start: vi.fn(), advance: vi.fn(), complete: vi.fn(), get: vi.fn(async () => baseSession), findRecent: vi.fn() },
     settingsRepo: { getOrDefault: vi.fn(async () => ({ function_tooltip: true, auto_advance_on_hit: true, session_length: 30, reduced_motion: 'auto' as const, onboarded: true })), update: vi.fn() },
     getAudioContext: () => new (class { currentTime = 0; sampleRate = 48000; audioWorklet = { addModule: vi.fn(async () => undefined) }; createBuffer() { return {} as AudioBuffer; } createMediaStreamSource() { return { connect: vi.fn(), disconnect: vi.fn() }; } })() as unknown as AudioContext,
     getMicStream: async () => ({} as MediaStream),
@@ -339,6 +339,69 @@ describe('SessionController — next()', () => {
 
     await expect(ctrl.next()).resolves.toBeUndefined();
     expect(deps.sessionsRepo.complete).not.toHaveBeenCalled();
+  });
+
+  // Issue #157: between rounds the controller previously mutated
+  // completed_items in memory but never wrote it back to IDB. If the tab
+  // closed/crashed mid-session, the persisted row showed completed_items: 0
+  // even though N attempts existed. next() must call sessionsRepo.advance()
+  // on the non-terminal branch with the same counters it applies to
+  // this.session.
+  it('calls sessionsRepo.advance() with updated counters on the non-terminal branch', async () => {
+    const nextItem: Item = { ...baseItem, id: '1-C-major', degree: 1 };
+    const deps = makeDeps();
+    deps.itemsRepo.listAll = vi.fn(async () => [baseItem, nextItem]);
+    // Session with 5/30 done so far; pre-round pitch/label counters.
+    const session: Session = {
+      ...baseSession,
+      completed_items: 5,
+      target_items: 30,
+      pitch_pass_count: 4,
+      label_pass_count: 5,
+    };
+    const ctrl = createSessionController({ ...deps, session, firstItem: baseItem });
+
+    ctrl._forceState(gradedState);
+    ctrl._seedRoundHistory([{ itemId: baseItem.id, degree: baseItem.degree, key: baseItem.key }]);
+    // _forceState bypasses the #dispatch persistence path; simulate its
+    // effect on the running counters (pitch + label both passed this round).
+    ctrl._forceRunningCounters(5, 6);
+
+    await ctrl.next();
+
+    // Non-terminal branch: complete() must NOT fire, advance() must.
+    expect(deps.sessionsRepo.complete).not.toHaveBeenCalled();
+    expect(deps.sessionsRepo.advance).toHaveBeenCalledTimes(1);
+    expect(deps.sessionsRepo.advance).toHaveBeenCalledWith(
+      'sess-1',
+      {
+        completed_items: 6, // 5 (prior) + 1 (this round)
+        pitch_pass_count: 5, // running counter after this round
+        label_pass_count: 6, // running counter after this round
+      },
+    );
+    // The in-memory session should reflect the same counter the repo got.
+    expect(ctrl.session?.completed_items).toBe(6);
+  });
+
+  it('does NOT call advance() on the terminal branch (complete() fires instead)', async () => {
+    const deps = makeDeps();
+    const session: Session = {
+      ...baseSession,
+      completed_items: 29,
+      target_items: 30,
+      pitch_pass_count: 20,
+      label_pass_count: 25,
+    };
+    const ctrl = createSessionController({ ...deps, session, firstItem: baseItem });
+
+    ctrl._forceState(gradedState);
+    ctrl._forceRunningCounters(21, 26);
+
+    await ctrl.next();
+
+    expect(deps.sessionsRepo.complete).toHaveBeenCalledTimes(1);
+    expect(deps.sessionsRepo.advance).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/repos/interfaces.ts
+++ b/packages/core/src/repos/interfaces.ts
@@ -36,8 +36,36 @@ export interface CompleteSessionInput {
   label_pass_count: number;
 }
 
+/**
+ * Partial progress update written between rounds. Unlike `complete`, this
+ * never sets `ended_at` — the session remains open. See issue #157: without
+ * a mid-session write, a crash/reload after N rounds shows `completed_items: 0`
+ * on the persisted row even though N attempts are in the attempts store.
+ */
+export interface AdvanceSessionInput {
+  completed_items: number;
+  pitch_pass_count: number;
+  label_pass_count: number;
+}
+
 export interface SessionsRepo {
   start(input: StartSessionInput): Promise<Session>;
+  /**
+   * Persist mid-session progress without ending the session. Idempotent:
+   * multiple calls overwrite the row in place (no new rows). Leaves
+   * `ended_at` as-is (null for an in-flight session).
+   *
+   * Implementations silently no-op when the session id is unknown — matches
+   * the same shape as `complete`. Callers that require strict semantics
+   * should `get(id)` first.
+   *
+   * `completed_items` is expected to be monotonically non-decreasing in
+   * normal use (the session controller only ever increments it). Regressions
+   * are not rejected: the repo is a dumb writer, and a spurious decrease
+   * would indicate a controller bug that should be caught there, not masked
+   * here. A controller-level test guards the increment path.
+   */
+  advance(id: string, input: AdvanceSessionInput): Promise<void>;
   complete(id: string, input: CompleteSessionInput): Promise<void>;
   get(id: string): Promise<Session | undefined>;
   findRecent(limit: number): Promise<Session[]>;

--- a/packages/web-platform/src/store/sessions-repo.ts
+++ b/packages/web-platform/src/store/sessions-repo.ts
@@ -4,9 +4,15 @@ import type {
   SessionsRepo as _SessionsRepo,
   StartSessionInput,
   CompleteSessionInput,
+  AdvanceSessionInput,
 } from '@ear-training/core/repos/interfaces';
 
-export type { SessionsRepo, StartSessionInput, CompleteSessionInput } from '@ear-training/core/repos/interfaces';
+export type {
+  SessionsRepo,
+  StartSessionInput,
+  CompleteSessionInput,
+  AdvanceSessionInput,
+} from '@ear-training/core/repos/interfaces';
 
 export function createSessionsRepo(db: DB): _SessionsRepo {
   return {
@@ -23,6 +29,19 @@ export function createSessionsRepo(db: DB): _SessionsRepo {
       };
       await db.put('sessions', session);
       return session;
+    },
+
+    async advance(id: string, input: AdvanceSessionInput) {
+      // Read-then-write to preserve untouched fields (started_at, ended_at,
+      // target_items, tz_offset_ms). Mirrors complete()'s shape, but never
+      // sets ended_at — the session stays open.
+      //
+      // Silent no-op on unknown id matches complete()'s behavior; see
+      // AdvanceSessionInput doc in packages/core/src/repos/interfaces.ts.
+      const existing = await db.get('sessions', id);
+      if (!existing) return;
+      const updated: Session = { ...existing, ...input };
+      await db.put('sessions', updated);
     },
 
     async complete(id: string, input: CompleteSessionInput) {

--- a/packages/web-platform/tests/store/sessions-repo.test.ts
+++ b/packages/web-platform/tests/store/sessions-repo.test.ts
@@ -25,6 +25,90 @@ describe('sessions-repo', () => {
     expect(after?.pitch_pass_count).toBe(24);
   });
 
+  describe('advance (mid-session progress)', () => {
+    it('updates counters in place and leaves ended_at null', async () => {
+      const db = await openTestDB();
+      const repo = createSessionsRepo(db);
+
+      await repo.start({ id: 's1', target_items: 15, started_at: 100 });
+
+      await repo.advance('s1', {
+        completed_items: 3,
+        pitch_pass_count: 2,
+        label_pass_count: 3,
+      });
+
+      const after = await repo.get('s1');
+      expect(after?.completed_items).toBe(3);
+      expect(after?.pitch_pass_count).toBe(2);
+      expect(after?.label_pass_count).toBe(3);
+      expect(after?.ended_at).toBeNull();
+      expect(after?.started_at).toBe(100); // unchanged
+      expect(after?.target_items).toBe(15); // unchanged
+    });
+
+    it('multiple advance() calls overwrite the same row (no new rows)', async () => {
+      const db = await openTestDB();
+      const repo = createSessionsRepo(db);
+
+      await repo.start({ id: 's1', target_items: 15, started_at: 100 });
+      await repo.advance('s1', { completed_items: 1, pitch_pass_count: 1, label_pass_count: 1 });
+      await repo.advance('s1', { completed_items: 2, pitch_pass_count: 1, label_pass_count: 2 });
+      await repo.advance('s1', { completed_items: 3, pitch_pass_count: 2, label_pass_count: 3 });
+
+      const all = await repo.findRecent(10);
+      expect(all).toHaveLength(1);
+      expect(all[0]?.completed_items).toBe(3);
+      expect(all[0]?.pitch_pass_count).toBe(2);
+      expect(all[0]?.label_pass_count).toBe(3);
+      expect(all[0]?.ended_at).toBeNull();
+    });
+
+    it('advance() then complete() produces both updated counters and ended_at', async () => {
+      const db = await openTestDB();
+      const repo = createSessionsRepo(db);
+
+      await repo.start({ id: 's1', target_items: 15, started_at: 100 });
+      await repo.advance('s1', { completed_items: 14, pitch_pass_count: 10, label_pass_count: 12 });
+      await repo.complete('s1', {
+        ended_at: 500,
+        completed_items: 15,
+        pitch_pass_count: 11,
+        label_pass_count: 13,
+      });
+
+      const after = await repo.get('s1');
+      expect(after?.ended_at).toBe(500);
+      expect(after?.completed_items).toBe(15);
+      expect(after?.pitch_pass_count).toBe(11);
+      expect(after?.label_pass_count).toBe(13);
+    });
+
+    it('is a silent no-op on unknown id (matches complete() shape)', async () => {
+      // The repo is a dumb writer. If a caller advances an id that was never
+      // started, that indicates a controller bug upstream; silently ignoring
+      // keeps the surface consistent with `complete()`, which does the same.
+      const db = await openTestDB();
+      const repo = createSessionsRepo(db);
+
+      await expect(
+        repo.advance('nonexistent', { completed_items: 1, pitch_pass_count: 0, label_pass_count: 1 }),
+      ).resolves.toBeUndefined();
+      expect(await repo.get('nonexistent')).toBeUndefined();
+    });
+
+    it('preserves tz_offset_ms across advance()', async () => {
+      const db = await openTestDB();
+      const repo = createSessionsRepo(db);
+
+      await repo.start({ id: 's1', target_items: 15, started_at: 100, tz_offset_ms: -14_400_000 });
+      await repo.advance('s1', { completed_items: 5, pitch_pass_count: 3, label_pass_count: 4 });
+
+      const after = await repo.get('s1');
+      expect(after?.tz_offset_ms).toBe(-14_400_000);
+    });
+  });
+
   it('findRecent returns sessions sorted newest first', async () => {
     const db = await openTestDB();
     const repo = createSessionsRepo(db);


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  subgraph Before
    NextOld[next round N] --> GradeOld[gradeRound]
    GradeOld --> MemOld[in-memory:<br/>completed_items++]
    MemOld -.->|no write| IDBOld[(IDB)]
    FinalOld[final round] --> CompleteOld[sessionsRepo.complete]
    CompleteOld --> IDBOld
  end

  subgraph After
    NextNew[next round N] --> GradeNew[gradeRound]
    GradeNew --> MemNew[in-memory:<br/>completed_items++]
    MemNew --> AdvanceNew[sessionsRepo.advance<br/>completed_items,<br/>pitch_pass, label_pass]
    AdvanceNew --> IDBNew[(IDB row updated)]
    FinalNew[final round] --> CompleteNew[sessionsRepo.complete<br/>sets ended_at]
    CompleteNew --> IDBNew
  end
```

## Summary

- Adds `advance(id, { completed_items, pitch_pass_count, label_pass_count })` to `SessionsRepo` interface + web-platform implementation
- Wires `advance()` into `session-controller.next()` on the non-terminal branch, so counters persist between rounds instead of only on final `complete()`
- Unblocks resume-on-reload work (referenced by #155 RCA Option C) — mid-session reload no longer reads a stale `completed_items: 0` from IDB
- Does NOT bump IDB schema version (only writes to existing fields within the `sessions` object store)

## Test plan

- [x] `pnpm run typecheck` — green
- [x] New repo-level tests: multi-advance updates row in place, doesn't set `ended_at`, monotonic `completed_items` enforced
- [x] New controller-level test: asserts `advance()` is called with correct counters between rounds; `complete()` still fires on final round
- [x] Per-package test runs all green (`pnpm --filter ear-training-station run test`, 116 pass)
- [ ] CI unit + integration green

Closes #157